### PR TITLE
feat: add GitHub Actions workflow for publishing SDK packages

### DIFF
--- a/.github/workflows/pub_publish.yaml
+++ b/.github/workflows/pub_publish.yaml
@@ -1,0 +1,53 @@
+name: pub_publish
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📚 Git Checkout
+        uses: actions/checkout@v4
+
+      - name: 🎯 Setup Dart
+        uses: dart-lang/setup-dart@v1
+
+      - name: 🐦 Setup Flutter
+        uses: subosito/flutter-action@v2
+
+      - name: 📦 Configure Pub Credentials
+        env:
+          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+        run: |
+          echo '$CLOUDSMITH_API_KEY' | flutter pub token add https://dart.cloudsmith.io/digizorg/default
+
+      - name: 📦 Publish Main SDK Package
+        working-directory: ./
+        run: |
+          flutter pub get
+          dart pub publish --dry-run
+          dart pub publish --force
+
+      - name: 📦 Publish Platform Interface Package
+        working-directory: ./luscii_patient_actions_sdk_platform_interface
+        run: |
+          flutter pub get
+          dart pub publish --dry-run
+          dart pub publish --force
+
+      - name: 📦 Publish Android Package
+        working-directory: ./luscii_patient_actions_sdk_android
+        run: |
+          flutter pub get
+          dart pub publish --dry-run
+          dart pub publish --force
+
+      - name: 📦 Publish iOS Package
+        working-directory: ./luscii_patient_actions_sdk_ios
+        run: |
+          flutter pub get
+          dart pub publish --dry-run
+          dart pub publish --force

--- a/luscii_patient_actions_sdk/pubspec.yaml
+++ b/luscii_patient_actions_sdk/pubspec.yaml
@@ -1,7 +1,8 @@
 name: luscii_patient_actions_sdk
 description: Luscii Patient Actions SDK plugin
 version: 0.2.0+1
-publish_to: none
+homepage: https://digizorg.app
+publish_to: https://dart.cloudsmith.io/digizorg/default/
 
 environment:
   sdk: ^3.8.1
@@ -18,11 +19,14 @@ dependencies:
   flutter:
     sdk: flutter
   luscii_patient_actions_sdk_android:
-    path: ../luscii_patient_actions_sdk_android
+    hosted: https://dart.cloudsmith.io/digizorg/default/
+    version: ^0.2.0+1
   luscii_patient_actions_sdk_ios:
-    path: ../luscii_patient_actions_sdk_ios
+    hosted: https://dart.cloudsmith.io/digizorg/default/
+    version: ^0.2.0+1
   luscii_patient_actions_sdk_platform_interface:
-    path: ../luscii_patient_actions_sdk_platform_interface
+    hosted: https://dart.cloudsmith.io/digizorg/default/
+    version: ^0.2.0+1
 
 dev_dependencies:
   flutter_test:

--- a/luscii_patient_actions_sdk_android/pubspec.yaml
+++ b/luscii_patient_actions_sdk_android/pubspec.yaml
@@ -1,7 +1,8 @@
 name: luscii_patient_actions_sdk_android
 description: Android implementation of the luscii_patient_actions_sdk plugin
 version: 0.2.0+1
-publish_to: none
+homepage: https://digizorg.app
+publish_to: https://dart.cloudsmith.io/digizorg/default/
 
 environment:
   sdk: ^3.8.1
@@ -19,7 +20,8 @@ dependencies:
   flutter:
     sdk: flutter
   luscii_patient_actions_sdk_platform_interface:
-    path: ../luscii_patient_actions_sdk_platform_interface
+    hosted: https://dart.cloudsmith.io/digizorg/default/
+    version: ^0.2.0+1
 
 dev_dependencies:
   flutter_test:

--- a/luscii_patient_actions_sdk_ios/pubspec.yaml
+++ b/luscii_patient_actions_sdk_ios/pubspec.yaml
@@ -1,7 +1,8 @@
 name: luscii_patient_actions_sdk_ios
 description: iOS implementation of the luscii_patient_actions_sdk plugin
 version: 0.2.0+1
-publish_to: none
+homepage: https://digizorg.app
+publish_to: https://dart.cloudsmith.io/digizorg/default/
 
 environment:
   sdk: ^3.8.1
@@ -18,7 +19,8 @@ dependencies:
   flutter:
     sdk: flutter
   luscii_patient_actions_sdk_platform_interface:
-    path: ../luscii_patient_actions_sdk_platform_interface
+    hosted: https://dart.cloudsmith.io/digizorg/default/
+    version: ^0.2.0+1
 
 dev_dependencies:
   flutter_test:

--- a/luscii_patient_actions_sdk_platform_interface/pubspec.yaml
+++ b/luscii_patient_actions_sdk_platform_interface/pubspec.yaml
@@ -1,7 +1,8 @@
 name: luscii_patient_actions_sdk_platform_interface
 description: A common platform interface for the luscii_patient_actions_sdk plugin.
 version: 0.2.0+1
-publish_to: none
+homepage: https://digizorg.app
+publish_to: https://dart.cloudsmith.io/digizorg/default/
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
## Description

This pull request introduces changes to enable publishing Dart and Flutter packages to a hosted repository on Cloudsmith, along with updates to package metadata and dependencies across multiple `pubspec.yaml` files. Key changes include the addition of a GitHub Actions workflow for automated publishing and the transition from local paths to hosted dependencies.

### Workflow Automation for Package Publishing:
* [`.github/workflows/pub_publish.yaml`](diffhunk://#diff-b782cf0b61b512616311a5443efeb096507a1c3f9bd4949f26004176e659852cR1-R53): Added a GitHub Actions workflow (`pub_publish`) to automate publishing Dart and Flutter packages to Cloudsmith upon tagging a version. This includes steps for Dart and Flutter setup, Pub credentials configuration, and publishing multiple packages (`main SDK`, `platform interface`, `Android`, and `iOS` implementations).

### Package Metadata Updates:
* [`luscii_patient_actions_sdk/pubspec.yaml`](diffhunk://#diff-985d5c213798aca9f6ed474c5874bdf8f67a3bf424982b2937ad092811ef5d94L4-R5): Updated metadata to include a homepage (`https://digizorg.app`) and set `publish_to` to the Cloudsmith repository (`https://dart.cloudsmith.io/digizorg/default/`).
* Similar updates were made to the `pubspec.yaml` files for the Android (`luscii_patient_actions_sdk_android`), iOS (`luscii_patient_actions_sdk_ios`), and platform interface (`luscii_patient_actions_sdk_platform_interface`) packages. [[1]](diffhunk://#diff-430152d0384873870971e2c94094255b6e4be1703451090aeab188eec9ff4d4eL4-R5) [[2]](diffhunk://#diff-5cf70cef1a07147633fede448e660858aebdab35ee43fad9a6e006eb84c0df31L4-R5) [[3]](diffhunk://#diff-89d3a3d0d8b10b55892f0129b982adf46ece6284b2893a11770cb5601efb2554L4-R5)

### Dependency Transition to Hosted Repository:
* [`luscii_patient_actions_sdk/pubspec.yaml`](diffhunk://#diff-985d5c213798aca9f6ed474c5874bdf8f67a3bf424982b2937ad092811ef5d94L21-R29): Changed dependencies (`Android`, `iOS`, and `platform interface`) from local paths to hosted versions on Cloudsmith, specifying version `^0.2.0+1`.
* Similar dependency updates were applied to the `pubspec.yaml` files for Android and iOS implementations. [[1]](diffhunk://#diff-430152d0384873870971e2c94094255b6e4be1703451090aeab188eec9ff4d4eL22-R24) [[2]](diffhunk://#diff-5cf70cef1a07147633fede448e660858aebdab35ee43fad9a6e006eb84c0df31L21-R23)

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore