### PR TITLE
Add environment selection (acceptance/test) support

### DIFF
--- a/luscii_patient_actions_sdk/CHANGELOG.md
+++ b/luscii_patient_actions_sdk/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0] - 2026-01-20
+
+### Added
+- Support for multiple environments (Production, Acceptance, Test).
+- `environment` parameter in `initialize` method to specify the target environment.
+- Note: Android requires build-time configuration for environment switching via Gradle properties.
 
 ## [0.6.0+1] - 2025-11-24
 

--- a/luscii_patient_actions_sdk/README.md
+++ b/luscii_patient_actions_sdk/README.md
@@ -116,6 +116,30 @@ class MainActivity: FlutterFragmentActivity() {
 ```
 FlutterActivity is not supported by Hilt, so we need to change it to a FlutterFragmentActivity. 
 
+### Environment Configuration
+
+#### iOS (runtime)
+
+Call `initialize` before using any other method to select the environment:
+
+```dart
+await initialize(
+  environment: LusciiEnvironment.acceptance, // or production (default), test
+);
+```
+
+#### Android (build-time)
+
+Android uses separate artifacts per environment. To use the **Acceptance** or **Test** environment, configure the SDK artifact in your app's `gradle.properties` file:
+
+```properties
+# For Acceptance Environment
+lusciiSdkArtifact=com.luscii:sdk-acceptance:0.8.2
+
+# For Production (Default - no need to add this line unless explicit)
+# lusciiSdkArtifact=com.luscii:sdk:0.8.2
+```
+
 
 
 

--- a/luscii_patient_actions_sdk/lib/luscii_patient_actions_sdk.dart
+++ b/luscii_patient_actions_sdk/lib/luscii_patient_actions_sdk.dart
@@ -6,15 +6,22 @@ import 'package:luscii_patient_actions_sdk/result/luscii_sdk_result.dart';
 import 'package:luscii_patient_actions_sdk_platform_interface/error/luscii_sdk_exception.dart';
 import 'package:luscii_patient_actions_sdk_platform_interface/luscii_patient_actions_sdk_platform_interface.dart';
 
+export 'package:luscii_patient_actions_sdk_platform_interface/luscii_patient_actions_sdk_platform_interface.dart'
+    show LusciiEnvironment;
+
 LusciiPatientActionsSdkPlatform get _platform =>
     LusciiPatientActionsSdkPlatform.instance;
 
 /// Initialize the SDK.
 Future<LusciiSdkResult<LusciiSdkNoResponse, LusciiSdkError>> initialize({
   bool androidDynamicTheming = false,
+  LusciiEnvironment environment = LusciiEnvironment.production,
 }) async {
   try {
-    await _platform.initialize(androidDynamicTheming: androidDynamicTheming);
+    await _platform.initialize(
+      androidDynamicTheming: androidDynamicTheming,
+      environment: environment,
+    );
     return const LusciiSdkSuccess(LusciiSdkNoResponse());
   } on PlatformException catch (e) {
     return LusciiSdkFailure(LusciiSdkError.fromErrorCode(e.code, e.message));

--- a/luscii_patient_actions_sdk/pubspec.yaml
+++ b/luscii_patient_actions_sdk/pubspec.yaml
@@ -1,6 +1,6 @@
 name: luscii_patient_actions_sdk
 description: Luscii Patient Actions SDK plugin
-version: 0.6.0+1
+version: 0.7.0
 repository: https://github.com/Digizorg/luscii_patient_actions_sdk
 homepage: https://github.com/Digizorg/luscii_patient_actions_sdk
 
@@ -19,9 +19,9 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  luscii_patient_actions_sdk_android: ^0.6.0
-  luscii_patient_actions_sdk_ios: ^0.6.0
-  luscii_patient_actions_sdk_platform_interface: ^0.6.0
+  luscii_patient_actions_sdk_android: ^0.7.0
+  luscii_patient_actions_sdk_ios: ^0.7.0
+  luscii_patient_actions_sdk_platform_interface: ^0.7.0
 
 dev_dependencies:
   flutter_test:

--- a/luscii_patient_actions_sdk_android/CHANGELOG.md
+++ b/luscii_patient_actions_sdk_android/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0] - 2026-01-20
+
+### Changed
+- Updated `build.gradle` to allow overriding the Luscii SDK artifact via `lusciiSdkArtifact` Gradle property for environment switching.
+- Updated `initialize` method to log a warning if an environment other than production is passed at runtime (Android relies on build-time config).
 
 ## [0.6.0+1] - 2025-11-24
 

--- a/luscii_patient_actions_sdk_android/android/build.gradle
+++ b/luscii_patient_actions_sdk_android/android/build.gradle
@@ -45,7 +45,8 @@ android {
     }
 
     dependencies {
-        implementation("com.luscii:sdk:0.8.2")
+        def lusciiSdkArtifact = project.findProperty('lusciiSdkArtifact') ?: "com.luscii:sdk:0.8.2"
+        implementation(lusciiSdkArtifact)
         implementation "com.google.dagger:hilt-android:2.57.2"
         implementation "androidx.fragment:fragment-ktx:1.8.6"
         kapt "com.google.dagger:hilt-compiler:2.57.2"

--- a/luscii_patient_actions_sdk_android/android/src/main/kotlin/nl/digizorg/LusciiPatientActionsSdkPlugin.kt
+++ b/luscii_patient_actions_sdk_android/android/src/main/kotlin/nl/digizorg/LusciiPatientActionsSdkPlugin.kt
@@ -56,7 +56,13 @@ class LusciiPatientActionsSdkPlugin : FlutterPlugin, MethodCallHandler, Activity
     override fun onMethodCall(call: MethodCall, result: Result) {
         when (call.method) {
             "initialize" -> {
-                val useDynamicColors = call.argument<Boolean>("useDynamicColors") ?: false
+                val useDynamicColors = call.argument<Boolean>("androidDynamicTheming") ?: false
+                val environment = call.argument<String>("environment")
+
+                if (environment != null && environment != "production") {
+                    println("WARNING: Android environment is determined by the 'lusciiSdkArtifact' Gradle property. " +
+                            "The 'environment' parameter '$environment' passed from Dart does not switch the native Android environment at runtime.")
+                }
 
                 luscii = Luscii {
                     applicationContext = activity?.applicationContext

--- a/luscii_patient_actions_sdk_android/lib/luscii_patient_actions_sdk_android.dart
+++ b/luscii_patient_actions_sdk_android/lib/luscii_patient_actions_sdk_android.dart
@@ -24,9 +24,26 @@ class LusciiPatientActionsSdkAndroid extends LusciiPatientActionsSdkPlatform {
   }
 
   @override
-  Future<void> initialize({bool androidDynamicTheming = false}) async {
-    await methodChannel.invokeMethod<void>('initialize', <String, bool>{
+  Future<void> initialize({
+    bool androidDynamicTheming = false,
+    LusciiEnvironment environment = LusciiEnvironment.production,
+  }) async {
+    String environmentString = 'production';
+    switch (environment) {
+      case LusciiEnvironment.production:
+        environmentString = 'production';
+        break;
+      case LusciiEnvironment.acceptance:
+        environmentString = 'accept';
+        break;
+      case LusciiEnvironment.test:
+        environmentString = 'test';
+        break;
+    }
+
+    await methodChannel.invokeMethod<void>('initialize', <String, dynamic>{
       'androidDynamicTheming': androidDynamicTheming,
+      'environment': environmentString,
     });
   }
 

--- a/luscii_patient_actions_sdk_android/pubspec.yaml
+++ b/luscii_patient_actions_sdk_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: luscii_patient_actions_sdk_android
 description: Android implementation of the luscii_patient_actions_sdk plugin
-version: 0.6.0+1
+version: 0.7.0
 repository: https://github.com/Digizorg/luscii_patient_actions_sdk
 homepage: https://github.com/Digizorg/luscii_patient_actions_sdk
 
@@ -20,7 +20,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  luscii_patient_actions_sdk_platform_interface: ^0.6.0
+  luscii_patient_actions_sdk_platform_interface: ^0.7.0
 
 dev_dependencies:
   flutter_test:

--- a/luscii_patient_actions_sdk_ios/CHANGELOG.md
+++ b/luscii_patient_actions_sdk_ios/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0] - 2026-01-20
+
+### Changed
+- Implemented runtime environment switching (Production, Acceptance, Test) via `initialize` method.
+- Updated plugin to handle initialization parameters and configure `UserDefaults` accordingly.
 
 ## [0.6.0+1] - 2025-11-24
 

--- a/luscii_patient_actions_sdk_ios/ios/Classes/errors/LusciiFlutterSdkError.swift
+++ b/luscii_patient_actions_sdk_ios/ios/Classes/errors/LusciiFlutterSdkError.swift
@@ -5,6 +5,7 @@ enum LusciiFlutterSdkError: Error {
     case invalidArguments(_ reason: String)
     case invalidAPIKey
     case unauthorized
+    case notInitialized
   
   var flutterError: FlutterError {
     switch self {
@@ -16,6 +17,8 @@ enum LusciiFlutterSdkError: Error {
       return .init(code: "2", message: "Invaild API Key", details: nil)
     case .unauthorized:
       return .init(code: "3", message: "Unauthorized", details: nil)
+    case .notInitialized:
+      return .init(code: "4", message: "Not initialized", details: nil)
     }
   }
 }

--- a/luscii_patient_actions_sdk_ios/lib/luscii_patient_actions_sdk_ios.dart
+++ b/luscii_patient_actions_sdk_ios/lib/luscii_patient_actions_sdk_ios.dart
@@ -22,10 +22,27 @@ class LusciiPatientActionsSdkIOS extends LusciiPatientActionsSdkPlatform {
   }
 
   @override
-  Future<void> initialize({bool androidDynamicTheming = false}) async {
-    // iOS does not support dynamic theming
-    // and does not require initialization
-    return Future.value();
+  Future<void> initialize({
+    bool androidDynamicTheming = false,
+    LusciiEnvironment environment = LusciiEnvironment.production,
+  }) async {
+    String environmentString = 'production';
+    switch (environment) {
+      case LusciiEnvironment.production:
+        environmentString = 'production';
+        break;
+      case LusciiEnvironment.acceptance:
+        environmentString = 'accept';
+        break;
+      case LusciiEnvironment.test:
+        environmentString = 'test';
+        break;
+    }
+
+    await methodChannel.invokeMethod<void>('initialize', <String, dynamic>{
+      'androidDynamicTheming': androidDynamicTheming,
+      'environment': environmentString,
+    });
   }
 
   @override

--- a/luscii_patient_actions_sdk_ios/pubspec.yaml
+++ b/luscii_patient_actions_sdk_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: luscii_patient_actions_sdk_ios
 description: iOS implementation of the luscii_patient_actions_sdk plugin
-version: 0.6.0+1
+version: 0.7.0
 repository: https://github.com/Digizorg/luscii_patient_actions_sdk
 homepage: https://github.com/Digizorg/luscii_patient_actions_sdk
 
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  luscii_patient_actions_sdk_platform_interface: ^0.6.0
+  luscii_patient_actions_sdk_platform_interface: ^0.7.0
 
 dev_dependencies:
   flutter_test:

--- a/luscii_patient_actions_sdk_platform_interface/CHANGELOG.md
+++ b/luscii_patient_actions_sdk_platform_interface/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0] - 2026-01-20
+
+### Added
+- `LusciiEnvironment` enum to support Production, Acceptance, and Test environments.
+- `environment` parameter to `initialize` method.
 
 ## [0.6.0+1] - 2025-11-24
 

--- a/luscii_patient_actions_sdk_platform_interface/lib/luscii_patient_actions_sdk_platform_interface.dart
+++ b/luscii_patient_actions_sdk_platform_interface/lib/luscii_patient_actions_sdk_platform_interface.dart
@@ -1,6 +1,18 @@
 import 'package:luscii_patient_actions_sdk_platform_interface/src/method_channel_luscii_patient_actions_sdk.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
+/// The environment to use for the Luscii SDK.
+enum LusciiEnvironment {
+  /// The production environment.
+  production,
+
+  /// The acceptance environment.
+  acceptance,
+
+  /// The test environment.
+  test,
+}
+
 /// The interface that implementations of
 /// luscii_patient_actions_sdk must implement.
 ///
@@ -33,7 +45,10 @@ abstract class LusciiPatientActionsSdkPlatform extends PlatformInterface {
   }
 
   /// Initialize the SDK.
-  Future<void> initialize({bool androidDynamicTheming});
+  Future<void> initialize({
+    bool androidDynamicTheming,
+    LusciiEnvironment environment,
+  });
 
   /// Authenticate the user with the given token.
   Future<void> authenticate(String apiKey);

--- a/luscii_patient_actions_sdk_platform_interface/lib/src/method_channel_luscii_patient_actions_sdk.dart
+++ b/luscii_patient_actions_sdk_platform_interface/lib/src/method_channel_luscii_patient_actions_sdk.dart
@@ -16,9 +16,26 @@ class MethodChannelLusciiPatientActionsSdk
   final eventChannel = const EventChannel('luscii_patient_actions_sdk/events');
 
   @override
-  Future<void> initialize({bool androidDynamicTheming = false}) async {
-    await methodChannel.invokeMethod<void>('initialize', <String, bool>{
+  Future<void> initialize({
+    bool androidDynamicTheming = false,
+    LusciiEnvironment environment = LusciiEnvironment.production,
+  }) async {
+    String environmentString = 'production';
+    switch (environment) {
+      case LusciiEnvironment.production:
+        environmentString = 'production';
+        break;
+      case LusciiEnvironment.acceptance:
+        environmentString = 'accept';
+        break;
+      case LusciiEnvironment.test:
+        environmentString = 'test';
+        break;
+    }
+
+    await methodChannel.invokeMethod<void>('initialize', <String, dynamic>{
       'androidDynamicTheming': androidDynamicTheming,
+      'environment': environmentString,
     });
   }
 

--- a/luscii_patient_actions_sdk_platform_interface/pubspec.yaml
+++ b/luscii_patient_actions_sdk_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: luscii_patient_actions_sdk_platform_interface
 description: A common platform interface for the luscii_patient_actions_sdk plugin.
-version: 0.6.0+1
+version: 0.7.0
 repository: https://github.com/Digizorg/luscii_patient_actions_sdk
 homepage: https://github.com/Digizorg/luscii_patient_actions_sdk
 


### PR DESCRIPTION
Adds LusciiEnvironment and initialize(environment) support across platform/interface.
iOS switches at runtime; Android uses Gradle artifact override and warns on runtime usage.
Docs + changelogs updated, versions bumped to 0.7.0.