### PR TITLE
feat(env): add environment selection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,30 @@ FlutterActivity is not supported by Hilt, so we need to change it to a FlutterFr
 
 
 
+## Environments
+
+By default, the SDK targets the **production** environment. You can switch to the **acceptance** environment for testing purposes.
+
+### Android
+
+To use the acceptance SDK on Android, add the following property to your `android/gradle.properties` file:
+
+```properties
+lusciiUseAcceptanceSdk=true
+```
+
+This will change the underlying dependency from `com.luscii:sdk` to `com.luscii:sdk-acceptance`.
+
+### iOS
+
+To target the acceptance environment on iOS, specify the `iOSEnvironment` parameter when initializing the SDK:
+
+```dart
+final result = await luscii_sdk.initialize(
+  iOSEnvironment: LusciiEnvironment.acceptance,
+);
+```
+
 ## Support
 
 This package is used in production and should be stable, but still expect frequent big API call changes

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ FlutterActivity is not supported by Hilt, so we need to change it to a FlutterFr
 
 ## Environments
 
-By default, the SDK targets the **production** environment. You can switch to the **acceptance** environment for testing purposes.
+By default, the SDK targets the **production** environment. You can switch to the **acceptance** or **test** environment for testing purposes.
 
 ### Android
 
@@ -131,15 +131,21 @@ To use the acceptance SDK on Android, add the following property to your `androi
 lusciiUseAcceptanceSdk=true
 ```
 
-This will change the underlying dependency from `com.luscii:sdk` to `com.luscii:sdk-acceptance`.
+To use the test SDK, use:
+
+```properties
+lusciiUseTestSdk=true
+```
+
+This will change the underlying dependency to `com.luscii:sdk-acceptance` or `com.luscii:sdk-test` respectively.
 
 ### iOS
 
-To target the acceptance environment on iOS, specify the `iOSEnvironment` parameter when initializing the SDK:
+To target the acceptance or test environment on iOS, specify the `iOSEnvironment` parameter when initializing the SDK:
 
 ```dart
 final result = await luscii_sdk.initialize(
-  iOSEnvironment: LusciiEnvironment.acceptance,
+  iOSEnvironment: LusciiEnvironment.acceptance, // or LusciiEnvironment.test
 );
 ```
 

--- a/luscii_patient_actions_sdk/CHANGELOG.md
+++ b/luscii_patient_actions_sdk/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0+1] - 2026-01-21
+
+### Added
+- Added support for configuring SDK environments (Production, Acceptance, Test).
+- Android: Added `lusciiUseAcceptanceSdk` and `lusciiUseTestSdk` Gradle properties to select the environment.
+- iOS: Added `iOSEnvironment` parameter to `initialize` method to select the environment.
+
 ## [0.7.0+1] - 2026-01-20
 
 ### Added

--- a/luscii_patient_actions_sdk/README.md
+++ b/luscii_patient_actions_sdk/README.md
@@ -119,6 +119,30 @@ FlutterActivity is not supported by Hilt, so we need to change it to a FlutterFr
 
 
 
+## Environments
+
+By default, the SDK targets the **production** environment. You can switch to the **acceptance** environment for testing purposes.
+
+### Android
+
+To use the acceptance SDK on Android, add the following property to your `android/gradle.properties` file:
+
+```properties
+lusciiUseAcceptanceSdk=true
+```
+
+This will change the underlying dependency from `com.luscii:sdk` to `com.luscii:sdk-acceptance`.
+
+### iOS
+
+To target the acceptance environment on iOS, specify the `iOSEnvironment` parameter when initializing the SDK:
+
+```dart
+final result = await luscii_sdk.initialize(
+  iOSEnvironment: LusciiEnvironment.acceptance,
+);
+```
+
 ## Support
 
 This package is used in production and should be stable, but still expect frequent big API call changes

--- a/luscii_patient_actions_sdk/README.md
+++ b/luscii_patient_actions_sdk/README.md
@@ -121,7 +121,7 @@ FlutterActivity is not supported by Hilt, so we need to change it to a FlutterFr
 
 ## Environments
 
-By default, the SDK targets the **production** environment. You can switch to the **acceptance** environment for testing purposes.
+By default, the SDK targets the **production** environment. You can switch to the **acceptance** or **test** environment for testing purposes.
 
 ### Android
 
@@ -131,15 +131,21 @@ To use the acceptance SDK on Android, add the following property to your `androi
 lusciiUseAcceptanceSdk=true
 ```
 
-This will change the underlying dependency from `com.luscii:sdk` to `com.luscii:sdk-acceptance`.
+To use the test SDK, use:
+
+```properties
+lusciiUseTestSdk=true
+```
+
+This will change the underlying dependency to `com.luscii:sdk-acceptance` or `com.luscii:sdk-test` respectively.
 
 ### iOS
 
-To target the acceptance environment on iOS, specify the `iOSEnvironment` parameter when initializing the SDK:
+To target the acceptance or test environment on iOS, specify the `iOSEnvironment` parameter when initializing the SDK:
 
 ```dart
 final result = await luscii_sdk.initialize(
-  iOSEnvironment: LusciiEnvironment.acceptance,
+  iOSEnvironment: LusciiEnvironment.acceptance, // or LusciiEnvironment.test
 );
 ```
 

--- a/luscii_patient_actions_sdk/example/lib/main.dart
+++ b/luscii_patient_actions_sdk/example/lib/main.dart
@@ -31,7 +31,11 @@ String get apiKey {
 Future<void> initApp() async {
   WidgetsFlutterBinding.ensureInitialized();
   debugPrint('Initializing SDK...');
-  final initialize = await luscii_sdk.initialize(androidDynamicTheming: true);
+  final initialize = await luscii_sdk.initialize(
+    androidDynamicTheming: true,
+    // ignore: avoid_redundant_argument_values
+    iOSEnvironment: luscii_sdk.LusciiEnvironment.production,
+  );
   if (initialize is LusciiSdkSuccess) {
     debugPrint('SDK initialized successfully');
   } else if (initialize is LusciiSdkFailure) {

--- a/luscii_patient_actions_sdk/lib/luscii_patient_actions_sdk.dart
+++ b/luscii_patient_actions_sdk/lib/luscii_patient_actions_sdk.dart
@@ -6,17 +6,23 @@ import 'package:luscii_patient_actions_sdk/result/luscii_sdk_result.dart';
 import 'package:luscii_patient_actions_sdk_platform_interface/error/luscii_sdk_exception.dart';
 import 'package:luscii_patient_actions_sdk_platform_interface/luscii_patient_actions_sdk_platform_interface.dart';
 
+export 'package:luscii_patient_actions_sdk_platform_interface/model/luscii_environment.dart';
+
 LusciiPatientActionsSdkPlatform get _platform =>
     LusciiPatientActionsSdkPlatform.instance;
 
-/// Initialize the SDK.
-Future<LusciiSdkResult<LusciiSdkNoResponse, LusciiSdkError>> initialize({
-  bool androidDynamicTheming = false,
-}) async {
-  try {
-    await _platform.initialize(androidDynamicTheming: androidDynamicTheming);
-    return const LusciiSdkSuccess(LusciiSdkNoResponse());
-  } on PlatformException catch (e) {
+  /// Initialize the SDK.
+  Future<LusciiSdkResult<LusciiSdkNoResponse, LusciiSdkError>> initialize({
+    bool androidDynamicTheming = false,
+    LusciiEnvironment iOSEnvironment = LusciiEnvironment.production,
+  }) async {
+    try {
+      await _platform.initialize(
+        androidDynamicTheming: androidDynamicTheming,
+        iOSEnvironment: iOSEnvironment,
+      );
+      return const LusciiSdkSuccess(LusciiSdkNoResponse());
+    } on PlatformException catch (e) {
     return LusciiSdkFailure(LusciiSdkError.fromErrorCode(e.code, e.message));
   }
 }

--- a/luscii_patient_actions_sdk/lib/luscii_patient_actions_sdk.dart
+++ b/luscii_patient_actions_sdk/lib/luscii_patient_actions_sdk.dart
@@ -11,18 +11,18 @@ export 'package:luscii_patient_actions_sdk_platform_interface/model/luscii_envir
 LusciiPatientActionsSdkPlatform get _platform =>
     LusciiPatientActionsSdkPlatform.instance;
 
-  /// Initialize the SDK.
-  Future<LusciiSdkResult<LusciiSdkNoResponse, LusciiSdkError>> initialize({
-    bool androidDynamicTheming = false,
-    LusciiEnvironment iOSEnvironment = LusciiEnvironment.production,
-  }) async {
-    try {
-      await _platform.initialize(
-        androidDynamicTheming: androidDynamicTheming,
-        iOSEnvironment: iOSEnvironment,
-      );
-      return const LusciiSdkSuccess(LusciiSdkNoResponse());
-    } on PlatformException catch (e) {
+/// Initialize the SDK.
+Future<LusciiSdkResult<LusciiSdkNoResponse, LusciiSdkError>> initialize({
+  bool androidDynamicTheming = false,
+  LusciiEnvironment iOSEnvironment = LusciiEnvironment.production,
+}) async {
+  try {
+    await _platform.initialize(
+      androidDynamicTheming: androidDynamicTheming,
+      iOSEnvironment: iOSEnvironment,
+    );
+    return const LusciiSdkSuccess(LusciiSdkNoResponse());
+  } on PlatformException catch (e) {
     return LusciiSdkFailure(LusciiSdkError.fromErrorCode(e.code, e.message));
   }
 }

--- a/luscii_patient_actions_sdk/pubspec.yaml
+++ b/luscii_patient_actions_sdk/pubspec.yaml
@@ -1,6 +1,6 @@
 name: luscii_patient_actions_sdk
 description: Luscii Patient Actions SDK plugin
-version: 0.7.0+1
+version: 0.8.0+1
 repository: https://github.com/Digizorg/luscii_patient_actions_sdk
 homepage: https://github.com/Digizorg/luscii_patient_actions_sdk
 
@@ -19,9 +19,9 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  luscii_patient_actions_sdk_android: ^0.7.0
-  luscii_patient_actions_sdk_ios: ^0.7.0
-  luscii_patient_actions_sdk_platform_interface: ^0.7.0
+  luscii_patient_actions_sdk_android: ^0.8.0
+  luscii_patient_actions_sdk_ios: ^0.8.0
+  luscii_patient_actions_sdk_platform_interface: ^0.8.0
 
 dev_dependencies:
   flutter_test:

--- a/luscii_patient_actions_sdk/test/luscii_patient_actions_sdk_test.dart
+++ b/luscii_patient_actions_sdk/test/luscii_patient_actions_sdk_test.dart
@@ -43,6 +43,10 @@ void main() {
 
     final mockEventData = {'actionID': 'action1', 'status': 'completed'};
 
+    setUpAll(() {
+      registerFallbackValue(LusciiEnvironment.production);
+    });
+
     setUp(() {
       lusciiPatientActionsSdkPlatform = MockLusciiPatientActionsSdkPlatform();
       LusciiPatientActionsSdkPlatform.instance =
@@ -53,6 +57,7 @@ void main() {
       when(
         () => lusciiPatientActionsSdkPlatform.initialize(
           androidDynamicTheming: any(named: 'androidDynamicTheming'),
+          iOSEnvironment: any(named: 'iOSEnvironment'),
         ),
       ).thenAnswer((_) => Future.value());
 
@@ -61,6 +66,7 @@ void main() {
       verify(
         () => lusciiPatientActionsSdkPlatform.initialize(
           androidDynamicTheming: true,
+          iOSEnvironment: any(named: 'iOSEnvironment'),
         ),
       ).called(1);
 
@@ -77,6 +83,7 @@ void main() {
       when(
         () => lusciiPatientActionsSdkPlatform.initialize(
           androidDynamicTheming: any(named: 'androidDynamicTheming'),
+          iOSEnvironment: any(named: 'iOSEnvironment'),
         ),
       ).thenThrow(PlatformException(code: '1', message: 'Invalid arguments'));
 

--- a/luscii_patient_actions_sdk_android/CHANGELOG.md
+++ b/luscii_patient_actions_sdk_android/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0+1] - 2026-01-21
+
+### Added
+- Added support for configuring SDK environments (Production, Acceptance, Test) via Gradle properties.
+
 ## [0.7.0+1] - 2026-01-20
 
 ### Added

--- a/luscii_patient_actions_sdk_android/android/build.gradle
+++ b/luscii_patient_actions_sdk_android/android/build.gradle
@@ -47,6 +47,8 @@ android {
     dependencies {
         if (project.hasProperty('lusciiUseAcceptanceSdk') && project.lusciiUseAcceptanceSdk == "true") {
             implementation("com.luscii:sdk-acceptance:0.8.2")
+        } else if (project.hasProperty('lusciiUseTestSdk') && project.lusciiUseTestSdk == "true") {
+            implementation("com.luscii:sdk-test:0.8.2")
         } else {
             implementation("com.luscii:sdk:0.8.2")
         }

--- a/luscii_patient_actions_sdk_android/android/build.gradle
+++ b/luscii_patient_actions_sdk_android/android/build.gradle
@@ -45,7 +45,11 @@ android {
     }
 
     dependencies {
-        implementation("com.luscii:sdk:0.8.2")
+        if (project.hasProperty('lusciiUseAcceptanceSdk') && project.lusciiUseAcceptanceSdk == "true") {
+            implementation("com.luscii:sdk-acceptance:0.8.2")
+        } else {
+            implementation("com.luscii:sdk:0.8.2")
+        }
         implementation "com.google.dagger:hilt-android:2.57.2"
         implementation "androidx.fragment:fragment-ktx:1.8.6"
         kapt "com.google.dagger:hilt-compiler:2.57.2"

--- a/luscii_patient_actions_sdk_android/lib/luscii_patient_actions_sdk_android.dart
+++ b/luscii_patient_actions_sdk_android/lib/luscii_patient_actions_sdk_android.dart
@@ -24,9 +24,13 @@ class LusciiPatientActionsSdkAndroid extends LusciiPatientActionsSdkPlatform {
   }
 
   @override
-  Future<void> initialize({bool androidDynamicTheming = false}) async {
-    await methodChannel.invokeMethod<void>('initialize', <String, bool>{
+  Future<void> initialize({
+    bool androidDynamicTheming = false,
+    LusciiEnvironment iOSEnvironment = LusciiEnvironment.production,
+  }) async {
+    await methodChannel.invokeMethod<void>('initialize', <String, dynamic>{
       'androidDynamicTheming': androidDynamicTheming,
+      'iOSEnvironment': iOSEnvironment.name,
     });
   }
 

--- a/luscii_patient_actions_sdk_android/lib/luscii_patient_actions_sdk_android.dart
+++ b/luscii_patient_actions_sdk_android/lib/luscii_patient_actions_sdk_android.dart
@@ -29,7 +29,7 @@ class LusciiPatientActionsSdkAndroid extends LusciiPatientActionsSdkPlatform {
     LusciiEnvironment iOSEnvironment = LusciiEnvironment.production,
   }) async {
     await methodChannel.invokeMethod<void>('initialize', <String, dynamic>{
-      'androidDynamicTheming': androidDynamicTheming,
+      'useDynamicColors': androidDynamicTheming,
       'iOSEnvironment': iOSEnvironment.name,
     });
   }

--- a/luscii_patient_actions_sdk_android/pubspec.yaml
+++ b/luscii_patient_actions_sdk_android/pubspec.yaml
@@ -1,7 +1,6 @@
 name: luscii_patient_actions_sdk_android
 description: Android implementation of the luscii_patient_actions_sdk plugin
-version: 0.7.0+1
-repository: https://github.com/Digizorg/luscii_patient_actions_sdk
+version: 0.8.0+1
 homepage: https://github.com/Digizorg/luscii_patient_actions_sdk
 
 environment:
@@ -15,12 +14,11 @@ flutter:
       android:
         package: nl.digizorg
         pluginClass: LusciiPatientActionsSdkPlugin
-        dartPluginClass: LusciiPatientActionsSdkAndroid
 
 dependencies:
   flutter:
     sdk: flutter
-  luscii_patient_actions_sdk_platform_interface: ^0.7.0
+  luscii_patient_actions_sdk_platform_interface: ^0.8.0
 
 dev_dependencies:
   flutter_test:

--- a/luscii_patient_actions_sdk_android/pubspec.yaml
+++ b/luscii_patient_actions_sdk_android/pubspec.yaml
@@ -14,6 +14,7 @@ flutter:
       android:
         package: nl.digizorg
         pluginClass: LusciiPatientActionsSdkPlugin
+        dartPluginClass: LusciiPatientActionsSdkAndroid
 
 dependencies:
   flutter:

--- a/luscii_patient_actions_sdk_android/test/luscii_patient_actions_sdk_android_test.dart
+++ b/luscii_patient_actions_sdk_android/test/luscii_patient_actions_sdk_android_test.dart
@@ -57,7 +57,10 @@ void main() {
 
       expect(log, hasLength(1));
       expect(log.first.method, 'initialize');
-      expect(log.first.arguments, {'androidDynamicTheming': false});
+      expect(log.first.arguments, {
+        'androidDynamicTheming': false,
+        'iOSEnvironment': 'production',
+      });
 
       // Clear log and test with custom value
       log.clear();
@@ -65,7 +68,10 @@ void main() {
 
       expect(log, hasLength(1));
       expect(log.first.method, 'initialize');
-      expect(log.first.arguments, {'androidDynamicTheming': true});
+      expect(log.first.arguments, {
+        'androidDynamicTheming': true,
+        'iOSEnvironment': 'production',
+      });
     });
 
     test('authenticate sends correct method call', () async {

--- a/luscii_patient_actions_sdk_android/test/luscii_patient_actions_sdk_android_test.dart
+++ b/luscii_patient_actions_sdk_android/test/luscii_patient_actions_sdk_android_test.dart
@@ -52,24 +52,23 @@ void main() {
     });
 
     test('initialize sends correct method call with parameters', () async {
-      // Test with default value
       await lusciiPatientActionsSdk.initialize();
 
       expect(log, hasLength(1));
       expect(log.first.method, 'initialize');
       expect(log.first.arguments, {
-        'androidDynamicTheming': false,
+        'useDynamicColors': false,
         'iOSEnvironment': 'production',
       });
 
-      // Clear log and test with custom value
       log.clear();
+
       await lusciiPatientActionsSdk.initialize(androidDynamicTheming: true);
 
       expect(log, hasLength(1));
       expect(log.first.method, 'initialize');
       expect(log.first.arguments, {
-        'androidDynamicTheming': true,
+        'useDynamicColors': true,
         'iOSEnvironment': 'production',
       });
     });

--- a/luscii_patient_actions_sdk_ios/CHANGELOG.md
+++ b/luscii_patient_actions_sdk_ios/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0+1] - 2026-01-21
+
+### Added
+- Added support for configuring SDK environments (Production, Acceptance, Test) via `initialize` method.
+
 ## [0.7.0+1] - 2026-01-20
 
 ### Added

--- a/luscii_patient_actions_sdk_ios/ios/Classes/LusciiPatientActionsSdkPlugin.swift
+++ b/luscii_patient_actions_sdk_ios/ios/Classes/LusciiPatientActionsSdkPlugin.swift
@@ -41,6 +41,8 @@ public class LusciiPatientActionsSdkPlugin: NSObject, FlutterPlugin {
          if let defaults = UserDefaults(suiteName: "com.luscii.Actions") {
              if environment == "acceptance" {
                  defaults.set("accept", forKey: "com.luscii.ActionsServerEnvironment")
+             } else if environment == "test" {
+                 defaults.set("test", forKey: "com.luscii.ActionsServerEnvironment")
              } else {
                  defaults.removeObject(forKey: "com.luscii.ActionsServerEnvironment")
              }

--- a/luscii_patient_actions_sdk_ios/ios/Classes/LusciiPatientActionsSdkPlugin.swift
+++ b/luscii_patient_actions_sdk_ios/ios/Classes/LusciiPatientActionsSdkPlugin.swift
@@ -34,6 +34,21 @@ public class LusciiPatientActionsSdkPlugin: NSObject, FlutterPlugin {
     }
 
     switch call.method {
+    case "initialize":
+      if let arguments = call.arguments as? [String: Any],
+         let environment = arguments["iOSEnvironment"] as? String {
+         
+         if let defaults = UserDefaults(suiteName: "com.luscii.Actions") {
+             if environment == "acceptance" {
+                 defaults.set("accept", forKey: "com.luscii.ActionsServerEnvironment")
+             } else {
+                 defaults.removeObject(forKey: "com.luscii.ActionsServerEnvironment")
+             }
+             // Force recreation of Luscii instance to pick up new environment settings
+             _luscii = nil
+         }
+      }
+      return result(nil)
     case "authenticate":
       // Check if argument is a String
       guard let value = call.arguments as? String else {

--- a/luscii_patient_actions_sdk_ios/lib/luscii_patient_actions_sdk_ios.dart
+++ b/luscii_patient_actions_sdk_ios/lib/luscii_patient_actions_sdk_ios.dart
@@ -22,10 +22,14 @@ class LusciiPatientActionsSdkIOS extends LusciiPatientActionsSdkPlatform {
   }
 
   @override
-  Future<void> initialize({bool androidDynamicTheming = false}) async {
-    // iOS does not support dynamic theming
-    // and does not require initialization
-    return Future.value();
+  Future<void> initialize({
+    bool androidDynamicTheming = false,
+    LusciiEnvironment iOSEnvironment = LusciiEnvironment.production,
+  }) async {
+    await methodChannel.invokeMethod<void>('initialize', <String, dynamic>{
+      'androidDynamicTheming': androidDynamicTheming,
+      'iOSEnvironment': iOSEnvironment.name,
+    });
   }
 
   @override

--- a/luscii_patient_actions_sdk_ios/lib/luscii_patient_actions_sdk_ios.dart
+++ b/luscii_patient_actions_sdk_ios/lib/luscii_patient_actions_sdk_ios.dart
@@ -27,7 +27,7 @@ class LusciiPatientActionsSdkIOS extends LusciiPatientActionsSdkPlatform {
     LusciiEnvironment iOSEnvironment = LusciiEnvironment.production,
   }) async {
     await methodChannel.invokeMethod<void>('initialize', <String, dynamic>{
-      'androidDynamicTheming': androidDynamicTheming,
+      'useDynamicColors': androidDynamicTheming,
       'iOSEnvironment': iOSEnvironment.name,
     });
   }

--- a/luscii_patient_actions_sdk_ios/pubspec.yaml
+++ b/luscii_patient_actions_sdk_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: luscii_patient_actions_sdk_ios
 description: iOS implementation of the luscii_patient_actions_sdk plugin
-version: 0.7.0+1
+version: 0.8.0+1
 repository: https://github.com/Digizorg/luscii_patient_actions_sdk
 homepage: https://github.com/Digizorg/luscii_patient_actions_sdk
 
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  luscii_patient_actions_sdk_platform_interface: ^0.7.0
+  luscii_patient_actions_sdk_platform_interface: ^0.8.0
 
 dev_dependencies:
   flutter_test:

--- a/luscii_patient_actions_sdk_ios/test/luscii_patient_actions_sdk_ios_test.dart
+++ b/luscii_patient_actions_sdk_ios/test/luscii_patient_actions_sdk_ios_test.dart
@@ -50,9 +50,22 @@ void main() {
     });
 
     test('initialize completes successfully', () async {
+      final log = <MethodCall>[];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(lusciiPatientActionsSdk.methodChannel, (
+            methodCall,
+          ) async {
+            log.add(methodCall);
+            return null;
+          });
+
       await expectLater(lusciiPatientActionsSdk.initialize(), completes);
-      // Initialize is a no-op on iOS, so no method call should be logged
-      expect(log, isEmpty);
+      expect(log, hasLength(1));
+      expect(log.first.method, 'initialize');
+      expect(log.first.arguments, {
+        'androidDynamicTheming': false,
+        'iOSEnvironment': 'production',
+      });
     });
 
     test('authenticate sends correct method call', () async {

--- a/luscii_patient_actions_sdk_ios/test/luscii_patient_actions_sdk_ios_test.dart
+++ b/luscii_patient_actions_sdk_ios/test/luscii_patient_actions_sdk_ios_test.dart
@@ -63,7 +63,7 @@ void main() {
       expect(log, hasLength(1));
       expect(log.first.method, 'initialize');
       expect(log.first.arguments, {
-        'androidDynamicTheming': false,
+        'useDynamicColors': false,
         'iOSEnvironment': 'production',
       });
     });

--- a/luscii_patient_actions_sdk_platform_interface/CHANGELOG.md
+++ b/luscii_patient_actions_sdk_platform_interface/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0+1] - 2026-01-21
+
+### Added
+- Added `LusciiEnvironment` enum for environment configuration (Production, Acceptance, Test).
+- Added `iOSEnvironment` parameter to `initialize` method in `LusciiPatientActionsSdkPlatform`.
+
 ## [0.7.0+1] - 2026-01-20
 
 ### Added

--- a/luscii_patient_actions_sdk_platform_interface/lib/luscii_patient_actions_sdk_platform_interface.dart
+++ b/luscii_patient_actions_sdk_platform_interface/lib/luscii_patient_actions_sdk_platform_interface.dart
@@ -1,5 +1,8 @@
+import 'package:luscii_patient_actions_sdk_platform_interface/model/luscii_environment.dart';
 import 'package:luscii_patient_actions_sdk_platform_interface/src/method_channel_luscii_patient_actions_sdk.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+export 'package:luscii_patient_actions_sdk_platform_interface/model/luscii_environment.dart';
 
 /// The interface that implementations of
 /// luscii_patient_actions_sdk must implement.
@@ -33,7 +36,10 @@ abstract class LusciiPatientActionsSdkPlatform extends PlatformInterface {
   }
 
   /// Initialize the SDK.
-  Future<void> initialize({bool androidDynamicTheming});
+  Future<void> initialize({
+    bool androidDynamicTheming = false,
+    LusciiEnvironment iOSEnvironment = LusciiEnvironment.production,
+  });
 
   /// Authenticate the user with the given token.
   Future<void> authenticate(String apiKey);

--- a/luscii_patient_actions_sdk_platform_interface/lib/model/luscii_environment.dart
+++ b/luscii_patient_actions_sdk_platform_interface/lib/model/luscii_environment.dart
@@ -5,4 +5,7 @@ enum LusciiEnvironment {
 
   /// The acceptance environment.
   acceptance,
+
+  /// The test environment.
+  test,
 }

--- a/luscii_patient_actions_sdk_platform_interface/lib/model/luscii_environment.dart
+++ b/luscii_patient_actions_sdk_platform_interface/lib/model/luscii_environment.dart
@@ -1,0 +1,8 @@
+/// The environment for the SDK.
+enum LusciiEnvironment {
+  /// The production environment.
+  production,
+
+  /// The acceptance environment.
+  acceptance,
+}

--- a/luscii_patient_actions_sdk_platform_interface/lib/src/method_channel_luscii_patient_actions_sdk.dart
+++ b/luscii_patient_actions_sdk_platform_interface/lib/src/method_channel_luscii_patient_actions_sdk.dart
@@ -3,8 +3,8 @@ import 'package:flutter/services.dart';
 import 'package:luscii_patient_actions_sdk_platform_interface/error/luscii_sdk_exception.dart';
 import 'package:luscii_patient_actions_sdk_platform_interface/luscii_patient_actions_sdk_platform_interface.dart';
 
-/// An implementation of [LusciiPatientActionsSdkPlatform]
-/// that uses method channels.
+/// An implementation of [LusciiPatientActionsSdkPlatform] that uses method
+/// channels.
 class MethodChannelLusciiPatientActionsSdk
     extends LusciiPatientActionsSdkPlatform {
   /// The method channel used to interact with the native platform.
@@ -16,9 +16,13 @@ class MethodChannelLusciiPatientActionsSdk
   final eventChannel = const EventChannel('luscii_patient_actions_sdk/events');
 
   @override
-  Future<void> initialize({bool androidDynamicTheming = false}) async {
-    await methodChannel.invokeMethod<void>('initialize', <String, bool>{
+  Future<void> initialize({
+    bool androidDynamicTheming = false,
+    LusciiEnvironment iOSEnvironment = LusciiEnvironment.production,
+  }) async {
+    await methodChannel.invokeMethod<void>('initialize', <String, dynamic>{
       'androidDynamicTheming': androidDynamicTheming,
+      'iOSEnvironment': iOSEnvironment.name,
     });
   }
 

--- a/luscii_patient_actions_sdk_platform_interface/lib/src/method_channel_luscii_patient_actions_sdk.dart
+++ b/luscii_patient_actions_sdk_platform_interface/lib/src/method_channel_luscii_patient_actions_sdk.dart
@@ -21,7 +21,7 @@ class MethodChannelLusciiPatientActionsSdk
     LusciiEnvironment iOSEnvironment = LusciiEnvironment.production,
   }) async {
     await methodChannel.invokeMethod<void>('initialize', <String, dynamic>{
-      'androidDynamicTheming': androidDynamicTheming,
+      'useDynamicColors': androidDynamicTheming,
       'iOSEnvironment': iOSEnvironment.name,
     });
   }

--- a/luscii_patient_actions_sdk_platform_interface/pubspec.yaml
+++ b/luscii_patient_actions_sdk_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: luscii_patient_actions_sdk_platform_interface
 description: A common platform interface for the luscii_patient_actions_sdk plugin.
-version: 0.7.0+1
+version: 0.8.0+1
 repository: https://github.com/Digizorg/luscii_patient_actions_sdk
 homepage: https://github.com/Digizorg/luscii_patient_actions_sdk
 

--- a/luscii_patient_actions_sdk_platform_interface/test/luscii_patient_actions_sdk_platform_interface_test.dart
+++ b/luscii_patient_actions_sdk_platform_interface/test/luscii_patient_actions_sdk_platform_interface_test.dart
@@ -3,7 +3,10 @@ import 'package:luscii_patient_actions_sdk_platform_interface/luscii_patient_act
 
 class LusciiPatientActionsSdkMock extends LusciiPatientActionsSdkPlatform {
   @override
-  Future<void> initialize({bool androidDynamicTheming = false}) {
+  Future<void> initialize({
+    bool androidDynamicTheming = false,
+    LusciiEnvironment iOSEnvironment = LusciiEnvironment.production,
+  }) {
     // Successful initialization
     return Future.value();
   }


### PR DESCRIPTION
Introduce support for selecting production or acceptance environments in the SDK for both Android and iOS. Update initialization APIs, platform interfaces, and documentation to reflect the new environment configuration options.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
