### PR TITLE
fix(rename): getSelfcareActions to getSelfCareActions

### DIFF
--- a/.github/cspell.json
+++ b/.github/cspell.json
@@ -26,6 +26,8 @@
     "allprojects",
     "githubusername",
     "androidx",
+    "SelfCare",
+    "selfCare",
     "Selfcare",
     "selfcare",
     "Podspec"

--- a/luscii_patient_actions_sdk/CHANGELOG.md
+++ b/luscii_patient_actions_sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1+1] - 2026-01-23
+
+### Fixed
+- Fixed bug where `isPlanned`, `isSelfCare` and `isExtra` were null.
+- Renamed `getSelfcareActions` to `getSelfCareActions`.
+
 ## [0.8.0+2] - 2026-01-21
 
 ### Fixed

--- a/luscii_patient_actions_sdk/example/lib/main.dart
+++ b/luscii_patient_actions_sdk/example/lib/main.dart
@@ -125,15 +125,15 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
-  Future<void> getSelfcareActions() async {
+  Future<void> getSelfCareActions() async {
     // Reset error state before making the request
     setState(() {
       errorMessage = null;
     });
 
     try {
-      debugPrint('Starting getSelfcareActions API call...');
-      final result = await luscii_sdk.getSelfcareActions();
+      debugPrint('Starting getSelfCareActions API call...');
+      final result = await luscii_sdk.getSelfCareActions();
       switch (result) {
         case LusciiSdkSuccess(value: final actions):
           debugPrint('Successfully received ${actions.length} actions');
@@ -167,8 +167,8 @@ class _HomePageState extends State<HomePage> {
             child: const Text('Get today actions'),
           ),
           TextButton(
-            onPressed: getSelfcareActions,
-            child: const Text('Get selfcare actions'),
+            onPressed: getSelfCareActions,
+            child: const Text('Get selfCare actions'),
           ),
           if (errorMessage != null)
             Padding(

--- a/luscii_patient_actions_sdk/lib/luscii_patient_actions_sdk.dart
+++ b/luscii_patient_actions_sdk/lib/luscii_patient_actions_sdk.dart
@@ -66,9 +66,9 @@ getTodayActions() async {
 
 /// Get the actions for the authenticated user.
 Future<LusciiSdkResult<List<LusciiSdkAction>, LusciiSdkError>>
-getSelfcareActions() async {
+getSelfCareActions() async {
   try {
-    final actions = await _platform.getSelfcareActions();
+    final actions = await _platform.getSelfCareActions();
     return LusciiSdkSuccess(
       actions
           .map(

--- a/luscii_patient_actions_sdk/pubspec.yaml
+++ b/luscii_patient_actions_sdk/pubspec.yaml
@@ -1,6 +1,6 @@
 name: luscii_patient_actions_sdk
 description: Luscii Patient Actions SDK plugin
-version: 0.8.0+2
+version: 0.8.1+1
 repository: https://github.com/Digizorg/luscii_patient_actions_sdk
 homepage: https://github.com/Digizorg/luscii_patient_actions_sdk
 
@@ -19,9 +19,9 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  luscii_patient_actions_sdk_android: ^0.8.0
-  luscii_patient_actions_sdk_ios: ^0.8.0
-  luscii_patient_actions_sdk_platform_interface: ^0.8.0
+  luscii_patient_actions_sdk_android: ^0.8.1
+  luscii_patient_actions_sdk_ios: ^0.8.1
+  luscii_patient_actions_sdk_platform_interface: ^0.8.1
 
 dev_dependencies:
   flutter_test:

--- a/luscii_patient_actions_sdk_android/CHANGELOG.md
+++ b/luscii_patient_actions_sdk_android/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1+1] - 2026-01-23
+
+### Fixed
+- Fixed bug where `isPlanned`, `isSelfCare` and `isExtra` were null.
+- Renamed `getSelfcareActions` to `getSelfCareActions`.
+
 ## [0.8.0+2] - 2026-01-21
 
 ### Fixed

--- a/luscii_patient_actions_sdk_android/android/src/main/kotlin/nl/digizorg/LusciiPatientActionsSdkPlugin.kt
+++ b/luscii_patient_actions_sdk_android/android/src/main/kotlin/nl/digizorg/LusciiPatientActionsSdkPlugin.kt
@@ -151,7 +151,7 @@ class LusciiPatientActionsSdkPlugin : FlutterPlugin, MethodCallHandler, Activity
                     return@launch
                 }
             }
-            "getSelfcareActions" -> {
+            "getSelfCareActions" -> {
                 // Check if the luscii instance is initialized
                 if (luscii == null) {
                     return result.error(

--- a/luscii_patient_actions_sdk_android/lib/luscii_patient_actions_sdk_android.dart
+++ b/luscii_patient_actions_sdk_android/lib/luscii_patient_actions_sdk_android.dart
@@ -55,9 +55,9 @@ class LusciiPatientActionsSdkAndroid extends LusciiPatientActionsSdkPlatform {
   }
 
   @override
-  Future<List<dynamic>> getSelfcareActions() async {
+  Future<List<dynamic>> getSelfCareActions() async {
     final actions = await methodChannel.invokeMethod<List<dynamic>>(
-      'getSelfcareActions',
+      'getSelfCareActions',
     );
 
     if (actions is! List) {

--- a/luscii_patient_actions_sdk_android/pubspec.yaml
+++ b/luscii_patient_actions_sdk_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: luscii_patient_actions_sdk_android
 description: Android implementation of the luscii_patient_actions_sdk plugin
-version: 0.8.0+2
+version: 0.8.1+1
 homepage: https://github.com/Digizorg/luscii_patient_actions_sdk
 
 environment:
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  luscii_patient_actions_sdk_platform_interface: ^0.8.0
+  luscii_patient_actions_sdk_platform_interface: ^0.8.1
 
 dev_dependencies:
   flutter_test:

--- a/luscii_patient_actions_sdk_android/test/luscii_patient_actions_sdk_android_test.dart
+++ b/luscii_patient_actions_sdk_android/test/luscii_patient_actions_sdk_android_test.dart
@@ -33,7 +33,7 @@ void main() {
                 return null;
               case 'getTodayActions':
                 return mockActions;
-              case 'getSelfcareActions':
+              case 'getSelfCareActions':
                 return mockActions;
               case 'launchAction':
                 return null;
@@ -109,29 +109,29 @@ void main() {
       );
     });
 
-    test('getSelfcareActions returns list of actions', () async {
-      final result = await lusciiPatientActionsSdk.getSelfcareActions();
+    test('getSelfCareActions returns list of actions', () async {
+      final result = await lusciiPatientActionsSdk.getSelfCareActions();
 
       expect(log, hasLength(1));
-      expect(log.first.method, 'getSelfcareActions');
+      expect(log.first.method, 'getSelfCareActions');
       expect(result, equals(mockActions));
     });
 
-    test('getSelfcareActions throws exception on invalid response', () async {
+    test('getSelfCareActions throws exception on invalid response', () async {
       // Override the mock to return null instead of a list
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(lusciiPatientActionsSdk.methodChannel, (
             methodCall,
           ) async {
             log.add(methodCall);
-            if (methodCall.method == 'getSelfcareActions') {
+            if (methodCall.method == 'getSelfCareActions') {
               return null;
             }
             return null;
           });
 
       expect(
-        () => lusciiPatientActionsSdk.getSelfcareActions(),
+        () => lusciiPatientActionsSdk.getSelfCareActions(),
         throwsA(isA<LusciiSdkException>()),
       );
     });

--- a/luscii_patient_actions_sdk_ios/CHANGELOG.md
+++ b/luscii_patient_actions_sdk_ios/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1+1] - 2026-01-23
+
+### Fixed
+- Fixed bug where `isPlanned`, `isSelfCare` and `isExtra` were null.
+- Renamed `getSelfcareActions` to `getSelfCareActions`.
+
 ## [0.8.0+2] - 2026-01-21
 
 ### Fixed

--- a/luscii_patient_actions_sdk_ios/ios/Classes/LusciiPatientActionsSdkPlugin.swift
+++ b/luscii_patient_actions_sdk_ios/ios/Classes/LusciiPatientActionsSdkPlugin.swift
@@ -96,8 +96,8 @@ public class LusciiPatientActionsSdkPlugin: NSObject, FlutterPlugin {
       Task {
         do {
           let todayActions = try await luscii.todayActions()
-          let selfcareActions = try await luscii.selfCareActions()
-          let actions = selfcareActions + todayActions
+          let selfCareActions = try await luscii.selfCareActions()
+          let actions = selfCareActions + todayActions
           let matchingAction = actions.first(where: { $0.id.uuidString == actionId })
           guard let matchingAction else {
             let error = LusciiFlutterSdkError.invalidArguments("Action not found")
@@ -132,7 +132,7 @@ public class LusciiPatientActionsSdkPlugin: NSObject, FlutterPlugin {
           }
         }
       }
-    case "getSelfcareActions":
+    case "getSelfCareActions":
       Task {
         do {
           let actions = try await luscii.selfCareActions().map { $0.toMap() }

--- a/luscii_patient_actions_sdk_ios/ios/Classes/extensions/Action+Extension.swift
+++ b/luscii_patient_actions_sdk_ios/ios/Classes/extensions/Action+Extension.swift
@@ -9,7 +9,10 @@ extension Action {
       "icon": icon?.absoluteString,  // Convert URL to string
       "completedAt": completedAt?.timeIntervalSince1970,  // Convert Date to timestamp
       "launchableStatus": serializeLaunchableStatus(),
-      "isLaunchable": isLaunchable
+      "isLaunchable": isLaunchable,
+      "isPlanned": isPlanned,
+      "isSelfCare": isSelfCare,
+      "isExtra": isExtra
     ]
   }
   

--- a/luscii_patient_actions_sdk_ios/ios/luscii_patient_actions_sdk_ios.podspec
+++ b/luscii_patient_actions_sdk_ios/ios/luscii_patient_actions_sdk_ios.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'luscii_patient_actions_sdk_ios'
-  s.version          = '0.8.0'
+  s.version          = '0.8.1'
   s.summary          = 'An iOS implementation of the luscii_patient_actions_sdk plugin.'
   s.description      = <<-DESC
   An iOS implementation of the luscii_patient_actions_sdk plugin.

--- a/luscii_patient_actions_sdk_ios/lib/luscii_patient_actions_sdk_ios.dart
+++ b/luscii_patient_actions_sdk_ios/lib/luscii_patient_actions_sdk_ios.dart
@@ -53,9 +53,9 @@ class LusciiPatientActionsSdkIOS extends LusciiPatientActionsSdkPlatform {
   }
 
   @override
-  Future<List<dynamic>> getSelfcareActions() async {
+  Future<List<dynamic>> getSelfCareActions() async {
     final actions = await methodChannel.invokeMethod<List<dynamic>>(
-      'getSelfcareActions',
+      'getSelfCareActions',
     );
 
     if (actions is! List) {

--- a/luscii_patient_actions_sdk_ios/pubspec.yaml
+++ b/luscii_patient_actions_sdk_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: luscii_patient_actions_sdk_ios
 description: iOS implementation of the luscii_patient_actions_sdk plugin
-version: 0.8.0+2
+version: 0.8.1+1
 repository: https://github.com/Digizorg/luscii_patient_actions_sdk
 homepage: https://github.com/Digizorg/luscii_patient_actions_sdk
 
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  luscii_patient_actions_sdk_platform_interface: ^0.8.0
+  luscii_patient_actions_sdk_platform_interface: ^0.8.1
 
 dev_dependencies:
   flutter_test:

--- a/luscii_patient_actions_sdk_ios/test/luscii_patient_actions_sdk_ios_test.dart
+++ b/luscii_patient_actions_sdk_ios/test/luscii_patient_actions_sdk_ios_test.dart
@@ -31,7 +31,7 @@ void main() {
                 return null;
               case 'getTodayActions':
                 return mockActions;
-              case 'getSelfcareActions':
+              case 'getSelfCareActions':
                 return mockActions;
               case 'launchAction':
                 return null;
@@ -103,29 +103,29 @@ void main() {
       );
     });
 
-    test('getSelfcareActions returns list of actions', () async {
-      final result = await lusciiPatientActionsSdk.getSelfcareActions();
+    test('getSelfCareActions returns list of actions', () async {
+      final result = await lusciiPatientActionsSdk.getSelfCareActions();
 
       expect(log, hasLength(1));
-      expect(log.first.method, 'getSelfcareActions');
+      expect(log.first.method, 'getSelfCareActions');
       expect(result, equals(mockActions));
     });
 
-    test('getSelfcareActions throws exception on invalid response', () async {
+    test('getSelfCareActions throws exception on invalid response', () async {
       // Override the mock to return null instead of a list
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(lusciiPatientActionsSdk.methodChannel, (
             methodCall,
           ) async {
             log.add(methodCall);
-            if (methodCall.method == 'getSelfcareActions') {
+            if (methodCall.method == 'getSelfCareActions') {
               return null;
             }
             return null;
           });
 
       expect(
-        () => lusciiPatientActionsSdk.getSelfcareActions(),
+        () => lusciiPatientActionsSdk.getSelfCareActions(),
         throwsA(isA<LusciiSdkException>()),
       );
     });

--- a/luscii_patient_actions_sdk_platform_interface/CHANGELOG.md
+++ b/luscii_patient_actions_sdk_platform_interface/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1+1] - 2026-01-23
+
+### Fixed
+- Fixed bug where `isPlanned`, `isSelfCare` and `isExtra` were null.
+- Renamed `getSelfcareActions` to `getSelfCareActions`.
+
 ## [0.8.0+2] - 2026-01-21
 
 ### Fixed

--- a/luscii_patient_actions_sdk_platform_interface/lib/luscii_patient_actions_sdk_platform_interface.dart
+++ b/luscii_patient_actions_sdk_platform_interface/lib/luscii_patient_actions_sdk_platform_interface.dart
@@ -47,8 +47,8 @@ abstract class LusciiPatientActionsSdkPlatform extends PlatformInterface {
   /// Get today's actions for the authenticated user.
   Future<List<dynamic>> getTodayActions();
 
-  /// Get selfcare actions for the authenticated user.
-  Future<List<dynamic>> getSelfcareActions();
+  /// Get selfCare actions for the authenticated user.
+  Future<List<dynamic>> getSelfCareActions();
 
   /// Launch the action with the given ID.
   Future<void> launchAction(String actionId);

--- a/luscii_patient_actions_sdk_platform_interface/lib/src/method_channel_luscii_patient_actions_sdk.dart
+++ b/luscii_patient_actions_sdk_platform_interface/lib/src/method_channel_luscii_patient_actions_sdk.dart
@@ -47,9 +47,9 @@ class MethodChannelLusciiPatientActionsSdk
   }
 
   @override
-  Future<List<dynamic>> getSelfcareActions() async {
+  Future<List<dynamic>> getSelfCareActions() async {
     final actions = await methodChannel.invokeMethod<List<dynamic>>(
-      'getSelfcareActions',
+      'getSelfCareActions',
     );
 
     if (actions is! List) {

--- a/luscii_patient_actions_sdk_platform_interface/pubspec.yaml
+++ b/luscii_patient_actions_sdk_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: luscii_patient_actions_sdk_platform_interface
 description: A common platform interface for the luscii_patient_actions_sdk plugin.
-version: 0.8.0+2
+version: 0.8.1+1
 repository: https://github.com/Digizorg/luscii_patient_actions_sdk
 homepage: https://github.com/Digizorg/luscii_patient_actions_sdk
 

--- a/luscii_patient_actions_sdk_platform_interface/test/luscii_patient_actions_sdk_platform_interface_test.dart
+++ b/luscii_patient_actions_sdk_platform_interface/test/luscii_patient_actions_sdk_platform_interface_test.dart
@@ -32,7 +32,7 @@ class LusciiPatientActionsSdkMock extends LusciiPatientActionsSdkPlatform {
   }
 
   @override
-  Future<List<dynamic>> getSelfcareActions() {
+  Future<List<dynamic>> getSelfCareActions() {
     return Future.value([
       {
         'icon': 'https://example.com/icon.png',


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Fixes 2 things:

- renamed everything to selfCare or SelfCare instead of selfcare and Selfcare
- Fixed a bug where on iOS the Flutter Action object didn't get `isPlanned`, `isSelfCare` and `isExtra`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
