### PR TITLE
fix: explicitly set production

### DIFF
--- a/luscii_patient_actions_sdk_ios/ios/Classes/LusciiPatientActionsSdkPlugin.swift
+++ b/luscii_patient_actions_sdk_ios/ios/Classes/LusciiPatientActionsSdkPlugin.swift
@@ -48,7 +48,7 @@ public class LusciiPatientActionsSdkPlugin: NSObject, FlutterPlugin {
              } else if environment == "test" {
                  defaults.set("test", forKey: "com.luscii.ActionsServerEnvironment")
              } else {
-                 defaults.removeObject(forKey: "com.luscii.ActionsServerEnvironment")
+                 defaults.set("production", forKey: "com.luscii.ActionsServerEnvironment")
              }
              // Force recreation of Luscii instance to pick up new environment settings
              _luscii = nil


### PR DESCRIPTION
We used to delete a key for production. This used to work fine. It seems that with the lastest version this is no longer supported and we should set production explicitly. 