### PR TITLE
fix: android hilt and double auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ final result = await luscii_sdk.initialize(
 
 This package is used in production and should be stable, but still expect frequent big API call changes
 
+## Authentication lifecycle (Android)
+
+As of `0.10.2+1`, Android authentication is stateful inside the plugin:
+
+- `initialize(...)` is idempotent. If the SDK instance already exists, the plugin returns success without creating a new instance.
+- After a successful `authenticate(apiKey)`, additional `authenticate` calls return success immediately.
+- The plugin does not call the native Luscii SDK `authenticate` again while it is already authenticated.
+
 | Function               | iOS Support | Android Support |
 |------------------------|-------------|-----------------|
 | `authenticate(String apiKey)` | ✅           | ✅               |

--- a/luscii_patient_actions_sdk/CHANGELOG.md
+++ b/luscii_patient_actions_sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2+1] - 2026-07-06
+
+### Changed
+- Bumped federated package dependencies to `^0.10.2`.
+- Bumped package version to `0.10.2+1`.
+
 ## [0.10.1+1] - 2026-06-29
 
 ### Fixed

--- a/luscii_patient_actions_sdk/README.md
+++ b/luscii_patient_actions_sdk/README.md
@@ -162,6 +162,14 @@ final result = await luscii_sdk.initialize(
 
 This package is used in production and should be stable, but still expect frequent big API call changes
 
+## Authentication lifecycle (Android)
+
+As of `0.10.2+1`, Android authentication is stateful inside the plugin:
+
+- `initialize(...)` is idempotent. If the SDK instance already exists, the plugin returns success without creating a new instance.
+- After a successful `authenticate(apiKey)`, additional `authenticate` calls return success immediately.
+- The plugin does not call the native Luscii SDK `authenticate` again while it is already authenticated.
+
 | Function               | iOS Support | Android Support |
 |------------------------|-------------|-----------------|
 | `authenticate(String apiKey)` | ✅           | ✅               |

--- a/luscii_patient_actions_sdk/example/android/app/build.gradle
+++ b/luscii_patient_actions_sdk/example/android/app/build.gradle
@@ -30,13 +30,13 @@ android {
     ndkVersion = "28.2.13676358"
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
         coreLibraryDesugaringEnabled true
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     sourceSets {

--- a/luscii_patient_actions_sdk/example/android/settings.gradle
+++ b/luscii_patient_actions_sdk/example/android/settings.gradle
@@ -20,7 +20,8 @@ plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version '8.13.0' apply false
     id "org.jetbrains.kotlin.android" version "2.2.0" apply false
-    id "com.google.dagger.hilt.android" version "2.58" apply false
+    //The app breaks runtime if we use hilt 2.58 here because of seemingly an issue with the third party SDK
+    id "com.google.dagger.hilt.android" version "2.57" apply false
 }
 
 include ":app"

--- a/luscii_patient_actions_sdk/example/lib/main.dart
+++ b/luscii_patient_actions_sdk/example/lib/main.dart
@@ -28,33 +28,8 @@ String get apiKey {
   return '<TEST_API_KEY>';
 }
 
-Future<void> initApp() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  debugPrint('Initializing SDK...');
-  final initialize = await luscii_sdk.initialize(
-    androidDynamicTheming: true,
-    // ignore: avoid_redundant_argument_values
-    iOSEnvironment: luscii_sdk.LusciiEnvironment.production,
-  );
-  if (initialize is LusciiSdkSuccess) {
-    debugPrint('SDK initialized successfully');
-  } else if (initialize is LusciiSdkFailure) {
-    debugPrint('SDK initialization failed');
-    debugPrint('Error: $initialize');
-  }
-
-  debugPrint('Authenticating with API key: ${apiKey.substring(0, 4)}...');
-  final lusciiPatientActionsSdk = await luscii_sdk.authenticate(apiKey);
-  if (lusciiPatientActionsSdk is LusciiSdkSuccess) {
-    debugPrint('Authenticated successfully');
-  } else if (lusciiPatientActionsSdk is LusciiSdkFailure) {
-    debugPrint('Authentication failed');
-    debugPrint('Error: $lusciiPatientActionsSdk');
-  }
-}
-
 Future<void> main() async {
-  await initApp();
+  WidgetsFlutterBinding.ensureInitialized();
   runApp(const MyApp());
 }
 
@@ -77,6 +52,24 @@ class HomePage extends StatefulWidget {
 class _HomePageState extends State<HomePage> {
   List<LusciiSdkAction>? actions;
   String? errorMessage;
+  bool isLoading = false;
+
+  Future<void> runWithLoading(Future<void> Function() operation) async {
+    if (isLoading) return;
+
+    setState(() {
+      isLoading = true;
+    });
+
+    try {
+      await operation();
+    } finally {
+      if (!mounted) return;
+      setState(() {
+        isLoading = false;
+      });
+    }
+  }
 
   @override
   void initState() {
@@ -122,6 +115,49 @@ class _HomePageState extends State<HomePage> {
       setState(() {
         errorMessage = 'Error: Unexpected error occurred - $e';
       });
+    }
+  }
+
+  Future<void> initializeSdk() async {
+    setState(() {
+      errorMessage = null;
+    });
+
+    debugPrint('Initializing SDK...');
+    final result = await luscii_sdk.initialize(
+      androidDynamicTheming: true,
+      iOSEnvironment: luscii_sdk.LusciiEnvironment.production,
+    );
+
+    switch (result) {
+      case LusciiSdkSuccess():
+        debugPrint('SDK initialized successfully');
+      case LusciiSdkFailure(exception: final exception):
+        debugPrint('SDK initialization failed');
+        debugPrint('Error: $exception');
+        setState(() {
+          errorMessage = 'Error: ${exception.reason}';
+        });
+    }
+  }
+
+  Future<void> authenticateSdk() async {
+    setState(() {
+      errorMessage = null;
+    });
+
+    debugPrint('Authenticating with API key: ${apiKey.substring(0, 4)}...');
+    final result = await luscii_sdk.authenticate(apiKey);
+
+    switch (result) {
+      case LusciiSdkSuccess():
+        debugPrint('Authenticated successfully');
+      case LusciiSdkFailure(exception: final exception):
+        debugPrint('Authentication failed');
+        debugPrint('Error: $exception');
+        setState(() {
+          errorMessage = 'Error: ${exception.reason}';
+        });
     }
   }
 
@@ -193,16 +229,27 @@ class _HomePageState extends State<HomePage> {
       appBar: AppBar(title: const Text('LusciiPatientActionsSdk Example')),
       body: Column(
         children: [
+          if (isLoading) const LinearProgressIndicator(),
           TextButton(
-            onPressed: getTodayActions,
+            onPressed: isLoading ? null : () => runWithLoading(initializeSdk),
+            child: const Text('Initialize SDK'),
+          ),
+          TextButton(
+            onPressed: isLoading ? null : () => runWithLoading(authenticateSdk),
+            child: const Text('Authenticate SDK'),
+          ),
+          TextButton(
+            onPressed: isLoading ? null : () => runWithLoading(getTodayActions),
             child: const Text('Get today actions'),
           ),
           TextButton(
-            onPressed: getSelfCareActions,
+            onPressed: isLoading
+                ? null
+                : () => runWithLoading(getSelfCareActions),
             child: const Text('Get selfCare actions'),
           ),
           TextButton(
-            onPressed: getExtraActions,
+            onPressed: isLoading ? null : () => runWithLoading(getExtraActions),
             child: const Text('Get extra actions'),
           ),
           if (errorMessage != null)

--- a/luscii_patient_actions_sdk/example/lib/main.dart
+++ b/luscii_patient_actions_sdk/example/lib/main.dart
@@ -125,10 +125,7 @@ class _HomePageState extends State<HomePage> {
     });
 
     debugPrint('Initializing SDK...');
-    final result = await luscii_sdk.initialize(
-      androidDynamicTheming: true,
-      iOSEnvironment: luscii_sdk.LusciiEnvironment.production,
-    );
+    final result = await luscii_sdk.initialize(androidDynamicTheming: true);
 
     switch (result) {
       case LusciiSdkSuccess():

--- a/luscii_patient_actions_sdk/example/lib/main.dart
+++ b/luscii_patient_actions_sdk/example/lib/main.dart
@@ -64,10 +64,11 @@ class _HomePageState extends State<HomePage> {
     try {
       await operation();
     } finally {
-      if (!mounted) return;
-      setState(() {
-        isLoading = false;
-      });
+      if (mounted) {
+        setState(() {
+          isLoading = false;
+        });
+      }
     }
   }
 

--- a/luscii_patient_actions_sdk/example/patrol_test/app_test.dart
+++ b/luscii_patient_actions_sdk/example/patrol_test/app_test.dart
@@ -6,7 +6,6 @@ import 'package:patrol/patrol.dart';
 void main() {
   patrolTest('Get actions flow test', ($) async {
     // Enable verbose logging for tests
-    await app.initApp();
     await $.pumpWidgetAndSettle(const app.MyApp());
 
     // Verify the app started correctly

--- a/luscii_patient_actions_sdk/pubspec.yaml
+++ b/luscii_patient_actions_sdk/pubspec.yaml
@@ -1,6 +1,6 @@
 name: luscii_patient_actions_sdk
 description: Luscii Patient Actions SDK plugin
-version: 0.10.1+1
+version: 0.10.2+1
 repository: https://github.com/Digizorg/luscii_patient_actions_sdk
 homepage: https://github.com/Digizorg/luscii_patient_actions_sdk
 
@@ -19,9 +19,9 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  luscii_patient_actions_sdk_android: ^0.10.1
-  luscii_patient_actions_sdk_ios: ^0.10.1
-  luscii_patient_actions_sdk_platform_interface: ^0.10.1
+  luscii_patient_actions_sdk_android: ^0.10.2
+  luscii_patient_actions_sdk_ios: ^0.10.2
+  luscii_patient_actions_sdk_platform_interface: ^0.10.2
 
 dev_dependencies:
   flutter_test:

--- a/luscii_patient_actions_sdk_android/CHANGELOG.md
+++ b/luscii_patient_actions_sdk_android/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2+1] - 2026-07-06
+
+### Fixed
+- Made Android `initialize` idempotent in the plugin: if already initialized, it now returns success without creating a new SDK instance.
+- Made Android authentication idempotent in the plugin: if already authenticated, `authenticate` now returns success without calling the native SDK again.
+- Reset tracked authentication state on first `initialize` and when native calls return `UnauthenticatedException`.
+
+### Changed
+- Updated platform interface dependency constraint to `^0.10.2`.
+
 ## [0.10.1+1] - 2026-06-29
 
 ### Changed

--- a/luscii_patient_actions_sdk_android/android/src/main/kotlin/nl/digizorg/LusciiPatientActionsSdkPlugin.kt
+++ b/luscii_patient_actions_sdk_android/android/src/main/kotlin/nl/digizorg/LusciiPatientActionsSdkPlugin.kt
@@ -42,6 +42,8 @@ class LusciiPatientActionsSdkPlugin : FlutterPlugin, MethodCallHandler, Activity
     // Store the action temporarily while waiting for disclaimer result
     private var pendingAction: Action? = null
 
+    private var isAuthenticated: Boolean = false
+
     private var fetchedTodaysTasks: List<Action>? = null
     private var fetchedSelfCareTasks: List<Action>? = null
     private var fetchedExtraTasks: List<Action>? = null
@@ -60,16 +62,24 @@ class LusciiPatientActionsSdkPlugin : FlutterPlugin, MethodCallHandler, Activity
     override fun onMethodCall(call: MethodCall, result: Result) {
         when (call.method) {
             "initialize" -> {
+                if (luscii != null) {
+                    return result.success(null)
+                }
+
                 val useDynamicColors = call.argument<Boolean>("useDynamicColors") ?: false
 
                 luscii = Luscii {
                     applicationContext = activity?.applicationContext
                     this.useDynamicColors = useDynamicColors
                 }
+                isAuthenticated = false
                 registerLauncherIfReady()
                 result.success(null)
             }
             "authenticate" -> {
+                if (isAuthenticated) {
+                    return result.success(null)
+                }
                 // Check if the luscii instance is initialized
                 if (luscii == null) {
                     return result.error(
@@ -91,6 +101,7 @@ class LusciiPatientActionsSdkPlugin : FlutterPlugin, MethodCallHandler, Activity
                         null
                     )
                 }
+
                 // Launch a coroutine in the IO context
                 CoroutineScope(Dispatchers.IO).launch {
                     try {
@@ -99,11 +110,13 @@ class LusciiPatientActionsSdkPlugin : FlutterPlugin, MethodCallHandler, Activity
 
                         when (authResult) {
                             is Luscii.AuthenticateResult.Success -> {
+                                isAuthenticated = true
                                 result.success(null);
                                 return@launch
                             }
 
                             is Luscii.AuthenticateResult.Invalid -> {
+                                isAuthenticated = false
                                 result.error(
                                     LusciiFlutterSdkError.UNAUTHORIZED.code,
                                     LusciiFlutterSdkError.UNAUTHORIZED.message,
@@ -139,6 +152,7 @@ class LusciiPatientActionsSdkPlugin : FlutterPlugin, MethodCallHandler, Activity
                         val actions = rawActions.map { it.toMap() }
                         result.success(actions)
                     } catch (e: UnauthenticatedException) {
+                        isAuthenticated = false
                         result.error(
                             LusciiFlutterSdkError.UNAUTHORIZED.code,
                             LusciiFlutterSdkError.UNAUTHORIZED.message,
@@ -173,6 +187,7 @@ class LusciiPatientActionsSdkPlugin : FlutterPlugin, MethodCallHandler, Activity
                         val actions = rawActions.map { it.toMap() }
                         result.success(actions)
                     } catch (e: UnauthenticatedException) {
+                        isAuthenticated = false
                         result.error(
                             LusciiFlutterSdkError.UNAUTHORIZED.code,
                             LusciiFlutterSdkError.UNAUTHORIZED.message,
@@ -207,6 +222,7 @@ class LusciiPatientActionsSdkPlugin : FlutterPlugin, MethodCallHandler, Activity
                     val actions = rawActions.map { it.toMap() }
                     result.success(actions)
                 } catch (e: UnauthenticatedException) {
+                    isAuthenticated = false
                     result.error(
                         LusciiFlutterSdkError.UNAUTHORIZED.code,
                         LusciiFlutterSdkError.UNAUTHORIZED.message,

--- a/luscii_patient_actions_sdk_android/pubspec.yaml
+++ b/luscii_patient_actions_sdk_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: luscii_patient_actions_sdk_android
 description: Android implementation of the luscii_patient_actions_sdk plugin
-version: 0.10.1+1
+version: 0.10.2+1
 homepage: https://github.com/Digizorg/luscii_patient_actions_sdk
 
 environment:
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  luscii_patient_actions_sdk_platform_interface: ^0.10.1
+  luscii_patient_actions_sdk_platform_interface: ^0.10.2
 
 dev_dependencies:
   flutter_test:

--- a/luscii_patient_actions_sdk_ios/CHANGELOG.md
+++ b/luscii_patient_actions_sdk_ios/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2+1] - 2026-07-06
+
+### Changed
+- Bumped package and podspec version to `0.10.2`.
+- Updated platform interface dependency constraint to `^0.10.2`.
+
 ## [0.10.1+1] - 2026-06-29
 
 ### Fixed

--- a/luscii_patient_actions_sdk_ios/pubspec.yaml
+++ b/luscii_patient_actions_sdk_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: luscii_patient_actions_sdk_ios
 description: iOS implementation of the luscii_patient_actions_sdk plugin
-version: 0.10.1+1
+version: 0.10.2+1
 repository: https://github.com/Digizorg/luscii_patient_actions_sdk
 homepage: https://github.com/Digizorg/luscii_patient_actions_sdk
 
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  luscii_patient_actions_sdk_platform_interface: ^0.10.1
+  luscii_patient_actions_sdk_platform_interface: ^0.10.2
 
 dev_dependencies:
   flutter_test:

--- a/luscii_patient_actions_sdk_platform_interface/CHANGELOG.md
+++ b/luscii_patient_actions_sdk_platform_interface/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2+1] - 2026-07-06
+
+### Changed
+- Bumped version to `0.10.2+1` to align with the federated package release.
+
 ## [0.10.1+1] - 2026-06-29
 
 ### Changed

--- a/luscii_patient_actions_sdk_platform_interface/pubspec.yaml
+++ b/luscii_patient_actions_sdk_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: luscii_patient_actions_sdk_platform_interface
 description: A common platform interface for the luscii_patient_actions_sdk plugin.
-version: 0.10.1+1
+version: 0.10.2+1
 repository: https://github.com/Digizorg/luscii_patient_actions_sdk
 homepage: https://github.com/Digizorg/luscii_patient_actions_sdk
 


### PR DESCRIPTION
Stuff breaks if you call authenticate again after already having launched a task previously. Adding some state to prevent additional authenticate calls at least covers the worst situations.