### PR TITLE
fix: invalidate session on log out

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ As of `0.10.2+1`, Android authentication is stateful inside the plugin:
 - After a successful `authenticate(apiKey)`, additional `authenticate` calls return success immediately.
 - The plugin does not call the native Luscii SDK `authenticate` again while it is already authenticated.
 - Call `logout()` when switching users. On Android this clears the local SDK instance and cached state.
+- After launching an action flow, Android blocks further `authenticate` calls for the rest of the app session as a temporary safeguard. Restart the app before authenticating again.
 
 | Function               | iOS Support | Android Support |
 |------------------------|-------------|-----------------|

--- a/README.md
+++ b/README.md
@@ -169,10 +169,12 @@ As of `0.10.2+1`, Android authentication is stateful inside the plugin:
 - `initialize(...)` is idempotent. If the SDK instance already exists, the plugin returns success without creating a new instance.
 - After a successful `authenticate(apiKey)`, additional `authenticate` calls return success immediately.
 - The plugin does not call the native Luscii SDK `authenticate` again while it is already authenticated.
+- Call `logout()` when switching users. On Android this clears the local SDK instance and cached state.
 
 | Function               | iOS Support | Android Support |
 |------------------------|-------------|-----------------|
 | `authenticate(String apiKey)` | ✅           | ✅               |
+| `logout()`                    | ✅           | ✅               |
 | `getTodayActions()`         | ✅           | ✅               |
 | `launchAction(String actionId)` | ✅           | ✅               |
 | `actionFlowStream()`   | ✅           | ✅ 

--- a/luscii_patient_actions_sdk/README.md
+++ b/luscii_patient_actions_sdk/README.md
@@ -170,6 +170,7 @@ As of `0.10.2+1`, Android authentication is stateful inside the plugin:
 - After a successful `authenticate(apiKey)`, additional `authenticate` calls return success immediately.
 - The plugin does not call the native Luscii SDK `authenticate` again while it is already authenticated.
 - Call `logout()` when switching users. On Android this clears the local SDK instance and cached state.
+- After launching an action flow, Android blocks further `authenticate` calls for the rest of the app session as a temporary safeguard. Restart the app before authenticating again.
 
 | Function               | iOS Support | Android Support |
 |------------------------|-------------|-----------------|

--- a/luscii_patient_actions_sdk/README.md
+++ b/luscii_patient_actions_sdk/README.md
@@ -169,10 +169,12 @@ As of `0.10.2+1`, Android authentication is stateful inside the plugin:
 - `initialize(...)` is idempotent. If the SDK instance already exists, the plugin returns success without creating a new instance.
 - After a successful `authenticate(apiKey)`, additional `authenticate` calls return success immediately.
 - The plugin does not call the native Luscii SDK `authenticate` again while it is already authenticated.
+- Call `logout()` when switching users. On Android this clears the local SDK instance and cached state.
 
 | Function               | iOS Support | Android Support |
 |------------------------|-------------|-----------------|
 | `authenticate(String apiKey)` | ✅           | ✅               |
+| `logout()`                    | ✅           | ✅               |
 | `getTodayActions()`         | ✅           | ✅               |
 | `launchAction(String actionId)` | ✅           | ✅               |
 | `actionFlowStream()`   | ✅           | ✅ 

--- a/luscii_patient_actions_sdk/example/lib/main.dart
+++ b/luscii_patient_actions_sdk/example/lib/main.dart
@@ -159,6 +159,29 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
+  Future<void> logoutSdk() async {
+    setState(() {
+      errorMessage = null;
+    });
+
+    debugPrint('Logging out from SDK...');
+    final result = await luscii_sdk.logout();
+
+    switch (result) {
+      case LusciiSdkSuccess():
+        debugPrint('Logged out successfully');
+        setState(() {
+          actions = null;
+        });
+      case LusciiSdkFailure(exception: final exception):
+        debugPrint('Logout failed');
+        debugPrint('Error: $exception');
+        setState(() {
+          errorMessage = 'Error: ${exception.reason}';
+        });
+    }
+  }
+
   Future<void> getSelfCareActions() async {
     // Reset error state before making the request
     setState(() {
@@ -235,6 +258,10 @@ class _HomePageState extends State<HomePage> {
           TextButton(
             onPressed: isLoading ? null : () => runWithLoading(authenticateSdk),
             child: const Text('Authenticate SDK'),
+          ),
+          TextButton(
+            onPressed: isLoading ? null : () => runWithLoading(logoutSdk),
+            child: const Text('Logout SDK'),
           ),
           TextButton(
             onPressed: isLoading ? null : () => runWithLoading(getTodayActions),

--- a/luscii_patient_actions_sdk/lib/error/luscii_sdk_error.dart
+++ b/luscii_patient_actions_sdk/lib/error/luscii_sdk_error.dart
@@ -45,7 +45,7 @@ enum LusciiSdkErrorType {
         return LusciiSdkErrorType.unauthorized;
       case '4':
         return LusciiSdkErrorType.invalidResponse;
-      case '7':
+      case '6':
         return LusciiSdkErrorType.reauthenticationNotAllowed;
       default:
         return LusciiSdkErrorType.unknown;

--- a/luscii_patient_actions_sdk/lib/error/luscii_sdk_error.dart
+++ b/luscii_patient_actions_sdk/lib/error/luscii_sdk_error.dart
@@ -29,6 +29,9 @@ enum LusciiSdkErrorType {
   /// The user is not authorized to perform the requested action.
   unauthorized,
 
+  /// Re-authentication is blocked after launching an action.
+  reauthenticationNotAllowed,
+
   /// The response from the SDK was invalid.
   invalidResponse;
 
@@ -42,6 +45,8 @@ enum LusciiSdkErrorType {
         return LusciiSdkErrorType.unauthorized;
       case '4':
         return LusciiSdkErrorType.invalidResponse;
+      case '7':
+        return LusciiSdkErrorType.reauthenticationNotAllowed;
       default:
         return LusciiSdkErrorType.unknown;
     }

--- a/luscii_patient_actions_sdk/lib/luscii_patient_actions_sdk.dart
+++ b/luscii_patient_actions_sdk/lib/luscii_patient_actions_sdk.dart
@@ -39,6 +39,16 @@ Future<LusciiSdkResult<LusciiSdkNoResponse, LusciiSdkError>> authenticate(
   }
 }
 
+/// Reset local SDK state and clear the active user session.
+Future<LusciiSdkResult<LusciiSdkNoResponse, LusciiSdkError>> logout() async {
+  try {
+    await _platform.logout();
+    return const LusciiSdkSuccess(LusciiSdkNoResponse());
+  } on PlatformException catch (e) {
+    return LusciiSdkFailure(LusciiSdkError.fromErrorCode(e.code, e.message));
+  }
+}
+
 /// Get the today actions for the authenticated user.
 Future<LusciiSdkResult<List<LusciiSdkAction>, LusciiSdkError>>
 getTodayActions() async {

--- a/luscii_patient_actions_sdk/test/luscii_patient_actions_sdk_test.dart
+++ b/luscii_patient_actions_sdk/test/luscii_patient_actions_sdk_test.dart
@@ -140,6 +140,41 @@ void main() {
       expect(failure.exception.reason, 'Invalid API key');
     });
 
+    test('logout - success', () async {
+      when(() => lusciiPatientActionsSdkPlatform.logout()).thenAnswer(
+        (_) => Future.value(),
+      );
+
+      final result = await logout();
+
+      verify(() => lusciiPatientActionsSdkPlatform.logout()).called(1);
+
+      expect(
+        result,
+        isA<LusciiSdkSuccess<LusciiSdkNoResponse, LusciiSdkError>>(),
+      );
+      final success =
+          result as LusciiSdkSuccess<LusciiSdkNoResponse, LusciiSdkError>;
+      expect(success.value, isA<LusciiSdkNoResponse>());
+    });
+
+    test('logout - platform exception', () async {
+      when(() => lusciiPatientActionsSdkPlatform.logout()).thenThrow(
+        PlatformException(code: '3', message: 'Unauthorized'),
+      );
+
+      final result = await logout();
+
+      expect(
+        result,
+        isA<LusciiSdkFailure<LusciiSdkNoResponse, LusciiSdkError>>(),
+      );
+      final failure =
+          result as LusciiSdkFailure<LusciiSdkNoResponse, LusciiSdkError>;
+      expect(failure.exception.type, LusciiSdkErrorType.unauthorized);
+      expect(failure.exception.reason, 'Unauthorized');
+    });
+
     test('getTodayActions - success', () async {
       when(
         () => lusciiPatientActionsSdkPlatform.getTodayActions(),

--- a/luscii_patient_actions_sdk/test/luscii_patient_actions_sdk_test.dart
+++ b/luscii_patient_actions_sdk/test/luscii_patient_actions_sdk_test.dart
@@ -140,6 +140,34 @@ void main() {
       expect(failure.exception.reason, 'Invalid API key');
     });
 
+    test('authenticate - re-authentication not allowed', () async {
+      const apiKey = 'test-api-key';
+
+      when(
+        () => lusciiPatientActionsSdkPlatform.authenticate(any()),
+      ).thenThrow(
+        PlatformException(
+          code: '7',
+          message:
+              'Re-authentication is not allowed after launching an action. '
+              'Call logout() and initialize() first',
+        ),
+      );
+
+      final result = await authenticate(apiKey);
+
+      expect(
+        result,
+        isA<LusciiSdkFailure<LusciiSdkNoResponse, LusciiSdkError>>(),
+      );
+      final failure =
+          result as LusciiSdkFailure<LusciiSdkNoResponse, LusciiSdkError>;
+      expect(
+        failure.exception.type,
+        LusciiSdkErrorType.reauthenticationNotAllowed,
+      );
+    });
+
     test('logout - success', () async {
       when(() => lusciiPatientActionsSdkPlatform.logout()).thenAnswer(
         (_) => Future.value(),

--- a/luscii_patient_actions_sdk/test/luscii_patient_actions_sdk_test.dart
+++ b/luscii_patient_actions_sdk/test/luscii_patient_actions_sdk_test.dart
@@ -143,9 +143,7 @@ void main() {
     test('authenticate - re-authentication not allowed', () async {
       const apiKey = 'test-api-key';
 
-      when(
-        () => lusciiPatientActionsSdkPlatform.authenticate(any()),
-      ).thenThrow(
+      when(() => lusciiPatientActionsSdkPlatform.authenticate(any())).thenThrow(
         PlatformException(
           code: '7',
           message:
@@ -169,9 +167,9 @@ void main() {
     });
 
     test('logout - success', () async {
-      when(() => lusciiPatientActionsSdkPlatform.logout()).thenAnswer(
-        (_) => Future.value(),
-      );
+      when(
+        () => lusciiPatientActionsSdkPlatform.logout(),
+      ).thenAnswer((_) => Future.value());
 
       final result = await logout();
 
@@ -187,9 +185,9 @@ void main() {
     });
 
     test('logout - platform exception', () async {
-      when(() => lusciiPatientActionsSdkPlatform.logout()).thenThrow(
-        PlatformException(code: '3', message: 'Unauthorized'),
-      );
+      when(
+        () => lusciiPatientActionsSdkPlatform.logout(),
+      ).thenThrow(PlatformException(code: '3', message: 'Unauthorized'));
 
       final result = await logout();
 

--- a/luscii_patient_actions_sdk/test/luscii_patient_actions_sdk_test.dart
+++ b/luscii_patient_actions_sdk/test/luscii_patient_actions_sdk_test.dart
@@ -145,7 +145,7 @@ void main() {
 
       when(() => lusciiPatientActionsSdkPlatform.authenticate(any())).thenThrow(
         PlatformException(
-          code: '7',
+          code: '6',
           message:
               'Re-authentication is not allowed after launching an action. '
               'Call logout() and initialize() first',

--- a/luscii_patient_actions_sdk_android/android/src/main/kotlin/nl/digizorg/LusciiPatientActionsSdkPlugin.kt
+++ b/luscii_patient_actions_sdk_android/android/src/main/kotlin/nl/digizorg/LusciiPatientActionsSdkPlugin.kt
@@ -43,6 +43,8 @@ class LusciiPatientActionsSdkPlugin : FlutterPlugin, MethodCallHandler, Activity
     private var pendingAction: Action? = null
 
     private var isAuthenticated: Boolean = false
+    private var lastAuthenticatedApiKey: String? = null
+    private var hasLaunchedActionSinceAuthentication: Boolean = false
 
     private var fetchedTodaysTasks: List<Action>? = null
     private var fetchedSelfCareTasks: List<Action>? = null
@@ -81,9 +83,6 @@ class LusciiPatientActionsSdkPlugin : FlutterPlugin, MethodCallHandler, Activity
                 result.success(null)
             }
             "authenticate" -> {
-                if (isAuthenticated) {
-                    return result.success(null)
-                }
                 // Check if the luscii instance is initialized
                 if (luscii == null) {
                     return result.error(
@@ -106,6 +105,18 @@ class LusciiPatientActionsSdkPlugin : FlutterPlugin, MethodCallHandler, Activity
                     )
                 }
 
+                if (hasLaunchedActionSinceAuthentication) {
+                    return result.error(
+                        LusciiFlutterSdkError.REAUTHENTICATION_NOT_ALLOWED.code,
+                        LusciiFlutterSdkError.REAUTHENTICATION_NOT_ALLOWED.message,
+                        null
+                    )
+                }
+
+                if (isAuthenticated && lastAuthenticatedApiKey == value) {
+                    return result.success(null)
+                }
+
                 // Launch a coroutine in the IO context
                 CoroutineScope(Dispatchers.IO).launch {
                     try {
@@ -115,12 +126,14 @@ class LusciiPatientActionsSdkPlugin : FlutterPlugin, MethodCallHandler, Activity
                         when (authResult) {
                             is Luscii.AuthenticateResult.Success -> {
                                 isAuthenticated = true
+                                lastAuthenticatedApiKey = value
                                 result.success(null);
                                 return@launch
                             }
 
                             is Luscii.AuthenticateResult.Invalid -> {
                                 isAuthenticated = false
+                                lastAuthenticatedApiKey = null
                                 result.error(
                                     LusciiFlutterSdkError.UNAUTHORIZED.code,
                                     LusciiFlutterSdkError.UNAUTHORIZED.message,
@@ -130,6 +143,8 @@ class LusciiPatientActionsSdkPlugin : FlutterPlugin, MethodCallHandler, Activity
                             }
                         }
                     } catch (e: Exception) {
+                        isAuthenticated = false
+                        lastAuthenticatedApiKey = null
                         // Handle any exception and send an error response
                         result.error(
                             LusciiFlutterSdkError.UNKNOWN.code,
@@ -346,6 +361,7 @@ class LusciiPatientActionsSdkPlugin : FlutterPlugin, MethodCallHandler, Activity
                         is DisclaimerResult.Accepted -> {
                             // Launch the pending action if disclaimer was accepted
                             pendingAction?.let { action ->
+                                hasLaunchedActionSinceAuthentication = true
                                 actionFlowLauncher?.launch(action)
                                 pendingAction = null
                             }
@@ -361,6 +377,7 @@ class LusciiPatientActionsSdkPlugin : FlutterPlugin, MethodCallHandler, Activity
 
     private fun clearLocalSdkState(resetSdkInstance: Boolean) {
         isAuthenticated = false
+        lastAuthenticatedApiKey = null
         pendingAction = null
         fetchedTodaysTasks = null
         fetchedSelfCareTasks = null

--- a/luscii_patient_actions_sdk_android/android/src/main/kotlin/nl/digizorg/LusciiPatientActionsSdkPlugin.kt
+++ b/luscii_patient_actions_sdk_android/android/src/main/kotlin/nl/digizorg/LusciiPatientActionsSdkPlugin.kt
@@ -76,6 +76,10 @@ class LusciiPatientActionsSdkPlugin : FlutterPlugin, MethodCallHandler, Activity
                 registerLauncherIfReady()
                 result.success(null)
             }
+            "logout" -> {
+                clearLocalSdkState(resetSdkInstance = true)
+                result.success(null)
+            }
             "authenticate" -> {
                 if (isAuthenticated) {
                     return result.success(null)
@@ -352,6 +356,22 @@ class LusciiPatientActionsSdkPlugin : FlutterPlugin, MethodCallHandler, Activity
                         }
                     }
                 }
+        }
+    }
+
+    private fun clearLocalSdkState(resetSdkInstance: Boolean) {
+        isAuthenticated = false
+        pendingAction = null
+        fetchedTodaysTasks = null
+        fetchedSelfCareTasks = null
+        fetchedExtraTasks = null
+
+        if (resetSdkInstance) {
+            actionFlowLauncher?.unregister()
+            disclaimerLauncher?.unregister()
+            actionFlowLauncher = null
+            disclaimerLauncher = null
+            luscii = null
         }
     }
 

--- a/luscii_patient_actions_sdk_android/android/src/main/kotlin/nl/digizorg/errors/LusciiFlutterSdkError.kt
+++ b/luscii_patient_actions_sdk_android/android/src/main/kotlin/nl/digizorg/errors/LusciiFlutterSdkError.kt
@@ -7,5 +7,5 @@ enum class LusciiFlutterSdkError(val code: String, val message: String) {
     UNAUTHORIZED("3", "Unauthorized"),
     NOT_INITIALIZED("4", "Luscii SDK not initialized"),
     UNSUPPORTED_VERSION("5", "Luscii SDK requires iOS 17.0 or higher"), // Only used by iOS
-    REAUTHENTICATION_NOT_ALLOWED("7", "Re-authentication is not allowed after launching an action in this app session. Restart the app"),
+    REAUTHENTICATION_NOT_ALLOWED("6", "Re-authentication is not allowed after launching an action in this app session. Restart the app"),
 }

--- a/luscii_patient_actions_sdk_android/android/src/main/kotlin/nl/digizorg/errors/LusciiFlutterSdkError.kt
+++ b/luscii_patient_actions_sdk_android/android/src/main/kotlin/nl/digizorg/errors/LusciiFlutterSdkError.kt
@@ -7,4 +7,5 @@ enum class LusciiFlutterSdkError(val code: String, val message: String) {
     UNAUTHORIZED("3", "Unauthorized"),
     NOT_INITIALIZED("4", "Luscii SDK not initialized"),
     UNSUPPORTED_VERSION("5", "Luscii SDK requires iOS 17.0 or higher"), // Only used by iOS
+    REAUTHENTICATION_NOT_ALLOWED("7", "Re-authentication is not allowed after launching an action in this app session. Restart the app"),
 }

--- a/luscii_patient_actions_sdk_android/lib/luscii_patient_actions_sdk_android.dart
+++ b/luscii_patient_actions_sdk_android/lib/luscii_patient_actions_sdk_android.dart
@@ -43,6 +43,11 @@ class LusciiPatientActionsSdkAndroid extends LusciiPatientActionsSdkPlatform {
   }
 
   @override
+  Future<void> logout() async {
+    await methodChannel.invokeMethod<void>('logout');
+  }
+
+  @override
   Future<List<dynamic>> getTodayActions() async {
     final actions = await methodChannel.invokeMethod<List<dynamic>>(
       'getTodayActions',

--- a/luscii_patient_actions_sdk_android/test/luscii_patient_actions_sdk_android_test.dart
+++ b/luscii_patient_actions_sdk_android/test/luscii_patient_actions_sdk_android_test.dart
@@ -31,6 +31,8 @@ void main() {
                 return null;
               case 'authenticate':
                 return null;
+              case 'logout':
+                return null;
               case 'getTodayActions':
                 return mockActions;
               case 'getSelfCareActions':
@@ -82,6 +84,14 @@ void main() {
       expect(log, hasLength(1));
       expect(log.first.method, 'authenticate');
       expect(log.first.arguments, apiKey);
+    });
+
+    test('logout sends correct method call', () async {
+      await lusciiPatientActionsSdk.logout();
+
+      expect(log, hasLength(1));
+      expect(log.first.method, 'logout');
+      expect(log.first.arguments, isNull);
     });
 
     test('getTodayActions returns list of actions', () async {

--- a/luscii_patient_actions_sdk_ios/ios/Classes/LusciiPatientActionsSdkPlugin.swift
+++ b/luscii_patient_actions_sdk_ios/ios/Classes/LusciiPatientActionsSdkPlugin.swift
@@ -79,6 +79,12 @@ public class LusciiPatientActionsSdkPlugin: NSObject, FlutterPlugin {
           }
         }
       }
+    case "logout":
+      _luscii = nil
+      fetchedTodaysTasks = nil
+      fetchedSelfCareTasks = nil
+      fetchedExtraTasks = nil
+      return result(nil)
     case "getTodayActions":
       Task {
         do {

--- a/luscii_patient_actions_sdk_ios/lib/luscii_patient_actions_sdk_ios.dart
+++ b/luscii_patient_actions_sdk_ios/lib/luscii_patient_actions_sdk_ios.dart
@@ -41,6 +41,11 @@ class LusciiPatientActionsSdkIOS extends LusciiPatientActionsSdkPlatform {
   }
 
   @override
+  Future<void> logout() async {
+    await methodChannel.invokeMethod<void>('logout');
+  }
+
+  @override
   Future<List<dynamic>> getTodayActions() async {
     final actions = await methodChannel.invokeMethod<List<dynamic>>(
       'getTodayActions',

--- a/luscii_patient_actions_sdk_ios/test/luscii_patient_actions_sdk_ios_test.dart
+++ b/luscii_patient_actions_sdk_ios/test/luscii_patient_actions_sdk_ios_test.dart
@@ -29,6 +29,8 @@ void main() {
             switch (methodCall.method) {
               case 'authenticate':
                 return null;
+              case 'logout':
+                return null;
               case 'getTodayActions':
                 return mockActions;
               case 'getSelfCareActions':
@@ -76,6 +78,13 @@ void main() {
       expect(log, hasLength(1));
       expect(log.first.method, 'authenticate');
       expect(log.first.arguments, apiKey);
+    });
+
+    test('logout sends correct method call', () async {
+      await lusciiPatientActionsSdk.logout();
+      expect(log, hasLength(1));
+      expect(log.first.method, 'logout');
+      expect(log.first.arguments, isNull);
     });
 
     test('getTodayActions returns list of actions', () async {

--- a/luscii_patient_actions_sdk_platform_interface/lib/luscii_patient_actions_sdk_platform_interface.dart
+++ b/luscii_patient_actions_sdk_platform_interface/lib/luscii_patient_actions_sdk_platform_interface.dart
@@ -44,6 +44,9 @@ abstract class LusciiPatientActionsSdkPlatform extends PlatformInterface {
   /// Authenticate the user with the given token.
   Future<void> authenticate(String apiKey);
 
+  /// Reset local SDK state and clear the active user session.
+  Future<void> logout();
+
   /// Get today's actions for the authenticated user.
   Future<List<dynamic>> getTodayActions();
 

--- a/luscii_patient_actions_sdk_platform_interface/lib/src/method_channel_luscii_patient_actions_sdk.dart
+++ b/luscii_patient_actions_sdk_platform_interface/lib/src/method_channel_luscii_patient_actions_sdk.dart
@@ -35,6 +35,11 @@ class MethodChannelLusciiPatientActionsSdk
   }
 
   @override
+  Future<void> logout() async {
+    await methodChannel.invokeMethod<void>('logout');
+  }
+
+  @override
   Future<List<dynamic>> getTodayActions() async {
     final actions = await methodChannel.invokeMethod<List<dynamic>>(
       'getTodayActions',

--- a/luscii_patient_actions_sdk_platform_interface/test/luscii_patient_actions_sdk_platform_interface_test.dart
+++ b/luscii_patient_actions_sdk_platform_interface/test/luscii_patient_actions_sdk_platform_interface_test.dart
@@ -18,6 +18,11 @@ class LusciiPatientActionsSdkMock extends LusciiPatientActionsSdkPlatform {
   }
 
   @override
+  Future<void> logout() {
+    return Future.value();
+  }
+
+  @override
   Future<List<dynamic>> getTodayActions() {
     return Future.value([
       {

--- a/luscii_patient_actions_sdk_platform_interface/test/src/method_channel_luscii_patient_actions_sdk_test.dart
+++ b/luscii_patient_actions_sdk_platform_interface/test/src/method_channel_luscii_patient_actions_sdk_test.dart
@@ -23,6 +23,8 @@ void main() {
                 return null;
               case 'authenticate':
                 return null;
+              case 'logout':
+                return null;
               case 'getTodayActions':
                 return <dynamic>['action1', 'action2'];
               case 'getSelfCareActions':
@@ -99,6 +101,27 @@ void main() {
           () => methodChannel.authenticate('test-api-key'),
           throwsA(isA<PlatformException>()),
         );
+      });
+    });
+
+    group('logout', () {
+      test('calls method channel without arguments', () async {
+        await methodChannel.logout();
+
+        expect(log, hasLength(1));
+        expect(log.first.method, 'logout');
+        expect(log.first.arguments, isNull);
+      });
+
+      test('throws PlatformException on failure', () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(methodChannel.methodChannel, (
+              methodCall,
+            ) async {
+              throw PlatformException(code: 'ERROR', message: 'logout failed');
+            });
+
+        expect(() => methodChannel.logout(), throwsA(isA<PlatformException>()));
       });
     });
 


### PR DESCRIPTION
The previous version implemented a work around for the luscii android sdk crashing (sending unhandled intents) in certain flows. This work around kept state alive in the extension.

This implementation has a bug. It has no way of invalidating the state on for instance a user switch or logout. This PR fixes that.

If a client now tries to reauthenticate in the bugged scenario an error is returned indicating the app has to be relaunched.