### PR TITLE
chore(deps): pin actions-sdk-ios to 2.2.0

### DIFF
--- a/luscii_patient_actions_sdk/CHANGELOG.md
+++ b/luscii_patient_actions_sdk/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1+1] - 2026-07-16
+
+### Fixed
+- iOS: Pinned the native `actions-sdk-ios` dependency to exactly `2.2.0`, preventing unintended upgrades to newer minor versions such as `2.3.0`.
+
+### Changed
+- Bumped package version to `0.11.1+1`.
+
 ## [0.11.0+1] - 2026-07-14
 
 ### Added

--- a/luscii_patient_actions_sdk/pubspec.yaml
+++ b/luscii_patient_actions_sdk/pubspec.yaml
@@ -1,6 +1,6 @@
 name: luscii_patient_actions_sdk
 description: Luscii Patient Actions SDK plugin
-version: 0.11.0+1
+version: 0.11.1+1
 repository: https://github.com/Digizorg/luscii_patient_actions_sdk
 homepage: https://github.com/Digizorg/luscii_patient_actions_sdk
 
@@ -19,9 +19,9 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  luscii_patient_actions_sdk_android: ^0.11.0
-  luscii_patient_actions_sdk_ios: ^0.11.0
-  luscii_patient_actions_sdk_platform_interface: ^0.11.0
+  luscii_patient_actions_sdk_android: ^0.11.1
+  luscii_patient_actions_sdk_ios: ^0.11.1
+  luscii_patient_actions_sdk_platform_interface: ^0.11.1
 
 dev_dependencies:
   flutter_test:

--- a/luscii_patient_actions_sdk_android/CHANGELOG.md
+++ b/luscii_patient_actions_sdk_android/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1+1] - 2026-07-16
+
+### Changed
+- Bumped version to `0.11.1+1` to align with the federated package release.
+
 ## [0.11.0+1] - 2026-07-14
 
 ### Changed

--- a/luscii_patient_actions_sdk_android/pubspec.yaml
+++ b/luscii_patient_actions_sdk_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: luscii_patient_actions_sdk_android
 description: Android implementation of the luscii_patient_actions_sdk plugin
-version: 0.11.0+1
+version: 0.11.1+1
 homepage: https://github.com/Digizorg/luscii_patient_actions_sdk
 
 environment:
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  luscii_patient_actions_sdk_platform_interface: ^0.11.0
+  luscii_patient_actions_sdk_platform_interface: ^0.11.1
 
 dev_dependencies:
   flutter_test:

--- a/luscii_patient_actions_sdk_ios/CHANGELOG.md
+++ b/luscii_patient_actions_sdk_ios/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1+1] - 2026-07-16
+
+### Fixed
+- Pinned the native `actions-sdk-ios` dependency to exactly `2.2.0` in `Package.swift` (previously `from: "2.2.0"`), preventing unintended upgrades to newer minor versions such as `2.3.0`.
+
+### Changed
+- Bumped package and podspec version to `0.11.1`.
+
 ## [0.11.0+1] - 2026-07-14
 
 ### Added

--- a/luscii_patient_actions_sdk_ios/ios/luscii_patient_actions_sdk_ios.podspec
+++ b/luscii_patient_actions_sdk_ios/ios/luscii_patient_actions_sdk_ios.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'luscii_patient_actions_sdk_ios'
-  s.version          = '0.11.0'
+  s.version          = '0.11.1'
   s.summary          = 'An iOS implementation of the luscii_patient_actions_sdk plugin.'
   s.description      = <<-DESC
   An iOS implementation of the luscii_patient_actions_sdk plugin.

--- a/luscii_patient_actions_sdk_ios/ios/luscii_patient_actions_sdk_ios/Package.swift
+++ b/luscii_patient_actions_sdk_ios/ios/luscii_patient_actions_sdk_ios/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // The Actions SDK. The `ActionsKit` product bundles the Actions, Centraal,
         // HTTPii and Measurements xcframeworks, so `import Actions` works transitively.
-        .package(url: "https://github.com/Luscii/actions-sdk-ios.git", from: "2.2.0")
+        .package(url: "https://github.com/Luscii/actions-sdk-ios.git", exact: "2.2.0")
     ],
     targets: [
         .target(

--- a/luscii_patient_actions_sdk_ios/pubspec.yaml
+++ b/luscii_patient_actions_sdk_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: luscii_patient_actions_sdk_ios
 description: iOS implementation of the luscii_patient_actions_sdk plugin
-version: 0.11.0+1
+version: 0.11.1+1
 repository: https://github.com/Digizorg/luscii_patient_actions_sdk
 homepage: https://github.com/Digizorg/luscii_patient_actions_sdk
 
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  luscii_patient_actions_sdk_platform_interface: ^0.11.0
+  luscii_patient_actions_sdk_platform_interface: ^0.11.1
 
 dev_dependencies:
   flutter_test:

--- a/luscii_patient_actions_sdk_platform_interface/CHANGELOG.md
+++ b/luscii_patient_actions_sdk_platform_interface/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1+1] - 2026-07-16
+
+### Changed
+- Bumped version to `0.11.1+1` to align with the federated package release.
+
 ## [0.11.0+1] - 2026-07-14
 
 ### Changed

--- a/luscii_patient_actions_sdk_platform_interface/pubspec.yaml
+++ b/luscii_patient_actions_sdk_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: luscii_patient_actions_sdk_platform_interface
 description: A common platform interface for the luscii_patient_actions_sdk plugin.
-version: 0.11.0+1
+version: 0.11.1+1
 repository: https://github.com/Digizorg/luscii_patient_actions_sdk
 homepage: https://github.com/Digizorg/luscii_patient_actions_sdk
 


### PR DESCRIPTION
Change the SPM dependency for Luscii Actions SDK to exact "2.2.0" in Package.swift to ensure deterministic builds and prevent automatic version updates.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
